### PR TITLE
docs: add contributor README and CI docs build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# FractalMind Docs Site
+
+VitePress documentation site for the FractalMind ecosystem.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 10+
+
+## Local Development
+
+```bash
+npm ci
+npm run docs:dev
+```
+
+## Build and Preview
+
+```bash
+npm run docs:build
+npm run docs:preview
+```
+
+## Deployment
+
+- GitHub Pages deploy is managed by `.github/workflows/deploy.yml`.
+- Deploys on pushes to `main`.
+
+## Contributing
+
+1. Keep protocol behavior docs synchronized with the Move contracts and SDK.
+2. For any API/state-machine change, update docs in the same PR.
+3. Include runnable examples whenever adding new flows.
+4. Prefer concise diagrams for lifecycle and authorization changes.


### PR DESCRIPTION
## Summary
- add top-level README with setup, build, deploy, and contribution flow
- add CI workflow that runs docs build on push/PR

## Validation
- 
pm run docs:build

## Why
- faster onboarding for contributors
- PRs now get an early docs-build signal before deploy