### PR TITLE
docs: add fractalmind-envd documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -41,6 +41,12 @@ export default defineConfig({
             { text: 'Quick Start', link: '/guide/quick-start' },
           ],
         },
+        {
+          text: 'Setup Guides',
+          items: [
+            { text: 'envd Quick Start', link: '/guide/envd-quickstart' },
+          ],
+        },
       ],
       '/architecture/': [
         {
@@ -59,6 +65,7 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/components/overview' },
             { text: 'fractalmind-protocol', link: '/components/protocol' },
+            { text: 'fractalmind-envd', link: '/components/envd' },
             { text: 'fractalbot', link: '/components/fractalbot' },
             { text: 'agent-manager', link: '/components/agent-manager' },
             { text: 'team-manager', link: '/components/team-manager' },

--- a/docs/components/envd.md
+++ b/docs/components/envd.md
@@ -1,0 +1,193 @@
+# fractalmind-envd
+
+Lightweight Go daemon for remote AI Agent management. Runs on each machine hosting AI agents, providing discovery, heartbeat monitoring, remote commands, and self-healing — all coordinated through SUI blockchain instead of a central server.
+
+## What Problem Does envd Solve?
+
+Managing AI agents across multiple machines today requires centralized tools (TeamViewer, Tailscale, SSH jump hosts) that create single points of failure and trust. If the central server goes down or revokes access, you lose control of your agents.
+
+**envd replaces the central server with SUI blockchain:**
+
+- Identity and authorization live on-chain — no vendor can revoke your access
+- Peer discovery happens through SUI Events — no coordination server needed
+- Data flows peer-to-peer through WireGuard tunnels — no relay by default
+- Every registration and status change is auditable on-chain
+
+## Architecture
+
+envd uses a **dual-plane architecture** inspired by Tailscale, but with SUI replacing the centralized coordination server:
+
+```
+SUI Blockchain (Control Plane — replaces Tailscale Coordination Server)
+├── PeerRegistry: WireGuard public key + endpoint registration
+├── AgentCertificate: Identity + permissions + reputation
+├── Organization: Membership (determines who can discover whom)
+├── Events: PeerRegistered / PeerUpdated / PeerOffline
+└── Governance: DAO on-chain voting
+
+envd (Single binary, runs on each machine)
+├── WireGuard: P2P mesh tunnels (data plane)
+├── SUI Client: Read peer list / register self / subscribe to events
+├── Agent Scanner: tmux session discovery
+├── Self-heal: Crash detection + auto-restart (max 3 attempts)
+├── REST API: Local management interface (coordinator mode)
+├── STUN Client: NAT endpoint discovery
+└── P2P Heartbeat: Direct node-to-node heartbeat
+
+TURN Relay (Optional, stateless)
+└── Forwards encrypted WireGuard packets only when P2P fails
+```
+
+### Connection Flow
+
+```
+1. envd starts
+   → Reads sentinel.yaml for SUI RPC, org_id, local keypair
+   → Generates WireGuard keypair (or loads existing)
+
+2. Registers on-chain
+   → Calls PeerRegistry::register_peer(cert, wg_pubkey, endpoints)
+   → SUI emits PeerRegistered event
+
+3. Discovers peers
+   → Queries historical PeerRegistered events (filtered by org_id)
+   → Subscribes to new events (real-time discovery)
+   → Establishes WireGuard tunnel to each peer
+
+4. P2P communication
+   → Heartbeat: envd ←WireGuard→ envd (direct)
+   → Commands: coordinator envd →WireGuard→ target envd
+   → Logs: target envd →WireGuard→ coordinator envd
+
+5. NAT traversal failure
+   → STUN discovers public endpoint
+   → Updates endpoint on-chain (PeerRegistry::update_endpoints)
+   → Still fails → TURN relay fallback
+```
+
+## Core Features
+
+### Agent Discovery
+Scans for local AI agents running as tmux sessions. Configurable scan interval (default 10s) with support for tmux, systemd, and Docker discovery methods.
+
+### Heartbeat Monitoring
+Sends periodic heartbeat via WireGuard P2P (not on-chain — to avoid gas costs). Default interval: 30s. Reports agent count, status, hostname, and uptime.
+
+### Remote Commands
+
+| Command | Description |
+|---------|-------------|
+| `status` | List all agents and their current status |
+| `restart <agent>` | Restart a specific agent's tmux session |
+| `kill <agent>` | Stop an agent's tmux session |
+| `logs <agent> [lines]` | Get recent agent logs (default: 100 lines) |
+| `shell <cmd>` | Execute an arbitrary shell command |
+
+### Self-Healing
+Automatically detects crashed agents (was running, now missing from tmux) and restarts them:
+- Detection within one scan interval (default 10s)
+- Maximum 3 restart attempts per agent
+- Alerts sent via Gateway/P2P when max attempts exhausted
+
+### SUI On-Chain Identity
+Each envd node has a SUI Ed25519 keypair and an `AgentCertificate`. Identity is verified on-chain — no passwords, no vendor accounts.
+
+### WireGuard P2P Mesh
+Data plane uses WireGuard (ChaCha20-Poly1305 encryption). Peers are added/removed dynamically based on SUI Events. ~95% P2P success rate (matching Tailscale).
+
+## Comparison with Alternatives
+
+| Feature | TeamViewer | Tailscale | **fractalmind-envd** |
+|---------|------------|-----------|---------------------|
+| **Trust root** | TV Master Server | Tailscale Coord Server | **SUI blockchain** |
+| **Control plane** | Centralized | Centralized | **On-chain (decentralized)** |
+| **Data plane** | P2P ~70% / relay | WireGuard P2P ~95% | **WireGuard P2P ~95%** |
+| **Identity** | ID + password | SSO + WG keys | **SUI keypair** |
+| **Peer discovery** | Master Server | Coordination Server | **SUI Events** |
+| **Encryption** | RSA4096 + AES256 E2E | WireGuard (ChaCha20) | **WireGuard (ChaCha20)** |
+| **Auditability** | Opaque | ACL logs | **Full on-chain record** |
+| **Single point of failure** | TV Master down | Coord Server down | **None (chain doesn't stop)** |
+| **Cost (2 nodes/month)** | ~$50.90 | ~$12 | **~$0.14** |
+| **Cost (100 nodes/month)** | N/A | ~$600 | **~$7.13** |
+
+**Key differentiator:** envd is the only remote agent management tool where identity, authorization, and peer discovery are fully decentralized on blockchain. No vendor can revoke your access or shut down the coordination layer.
+
+## SUI Smart Contracts
+
+envd deploys two Move modules as an independent package that depends on `fractalmind-protocol`:
+
+### `peer.move` — PeerRegistry
+
+Manages WireGuard public keys and endpoint registration for peer discovery via SUI Events.
+
+**Key functions:**
+
+| Function | Description |
+|----------|-------------|
+| `register_peer` | Register node with WG pubkey, endpoints, hostname. Requires active AgentCertificate. |
+| `update_endpoints` | Update endpoints when IP changes. Only the node itself can call. |
+| `go_offline` | Mark node offline (graceful shutdown). |
+| `go_online` | Mark node online with updated endpoints. |
+| `deregister_peer` | Remove node. Callable by node itself or org admin. |
+
+**Events emitted:**
+
+| Event | Triggered by | Contains |
+|-------|-------------|----------|
+| `PeerRegistered` | `register_peer` | peer address, org_id, WG pubkey, endpoints, hostname |
+| `PeerEndpointUpdated` | `update_endpoints`, `go_online` | peer address, org_id, new endpoints |
+| `PeerStatusChanged` | `go_offline`, `go_online` | peer address, org_id, new status |
+| `PeerDeregistered` | `deregister_peer` | peer address, org_id |
+
+### `sponsor.move` — Gas Sponsorship
+
+Manages organization-level gas sponsorship policies so worker nodes don't need to hold SUI tokens.
+
+| Function | Description |
+|----------|-------------|
+| `enable_sponsor` | Org admin enables gas sponsorship with per-tx and daily limits |
+| `get_sponsor` | Query sponsorship config for an org |
+
+The actual gas payment uses SUI's native Sponsored Transaction mechanism (SIP-15) — the on-chain contract only manages **policy** (limits, admin). A lightweight off-chain Gas Sponsor Service handles the dual-signing flow.
+
+## Testnet Deployment
+
+| Object | ID |
+|--------|----|
+| envd Package | `0x74aef8ff3bb0da5d5626780e6c0e5f1f36308a40580e519920fdc9204e73d958` |
+| PeerRegistry | `0xe557465293df033fd6ba1347706d7e9db2a35de4667a3b6a2e20252587b6e505` |
+| SponsorRegistry | `0x22db6a75b60b1f530e9779188c62c75a44340723d9d78e21f7e25ded29718511` |
+| Protocol Package | `0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24` |
+
+## Gas Cost Analysis
+
+envd operations are extremely cheap because only registration and status changes go on-chain — heartbeats and commands flow P2P:
+
+| Operation | Est. Gas (SUI) | Frequency |
+|-----------|---------------|-----------|
+| `register_peer` | ~0.0017 | On startup |
+| `update_endpoints` | ~0.0011 | On IP change |
+| `go_offline` / `go_online` | ~0.001 | On restart |
+| `deregister_peer` | ~0.0003 | On removal (storage rebate) |
+
+**Monthly cost estimates:**
+
+| Scale | Operations/month | Cost (SUI) | Cost (USD) |
+|-------|-----------------|------------|------------|
+| 2 nodes | ~100 | ~0.122 | **~$0.14** |
+| 100 nodes | ~5,000 | ~6.10 | **~$7.13** |
+
+## Related Components
+
+| Component | Relationship |
+|-----------|-------------|
+| [fractalmind-protocol](/components/protocol) | Provides `AgentCertificate` and `Organization` used for identity and authorization |
+| [agent-manager](/components/agent-manager) | Local agent lifecycle management; envd extends this to remote |
+| [fractalbot](/components/fractalbot) | Alerts routed through fractalbot when agent recovery fails |
+| [explorer](https://fractalmind-ai.github.io/explorer) | Visualizes peer nodes registered on-chain |
+
+## Source Code
+
+- GitHub: [fractalmind-ai/fractalmind-envd](https://github.com/fractalmind-ai/fractalmind-envd)
+- Language: Go 1.22+
+- License: MIT

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -9,6 +9,7 @@ These are the essential building blocks of the FractalMind stack.
 | Component | Repo | Language | Role | Status |
 |-----------|------|----------|------|--------|
 | [fractalmind-protocol](/components/protocol) | [GitHub](https://github.com/fractalmind-ai/fractalmind-protocol) | Move + TS | On-chain org/agent/task/governance | Stable |
+| [fractalmind-envd](/components/envd) | [GitHub](https://github.com/fractalmind-ai/fractalmind-envd) | Go | Remote agent management (SUI + WireGuard) | Active |
 | [agent-manager](/components/agent-manager) | [GitHub](https://github.com/fractalmind-ai/agent-manager-skill) | Python | Agent lifecycle (tmux) | Stable |
 | [team-manager](/components/team-manager) | [GitHub](https://github.com/fractalmind-ai/team-manager-skill) | Python | Team orchestration | Stable |
 | [fractalbot](/components/fractalbot) | [GitHub](https://github.com/fractalmind-ai/fractalbot) | Go | Multi-channel messaging | Active |
@@ -38,7 +39,6 @@ End-user products built on the FractalMind stack.
 
 | Component | Role | Phase |
 |-----------|------|-------|
-| fractalmind-envd | Remote agent environment daemon | Phase 3 |
 | Gateway Service | On-chain ↔ off-chain bridge | Phase 3 |
 
 ## How They Connect

--- a/docs/guide/envd-quickstart.md
+++ b/docs/guide/envd-quickstart.md
@@ -1,0 +1,357 @@
+# envd Quick Start
+
+This guide walks you through installing and running `fractalmind-envd` on a machine hosting AI agents.
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Go | 1.22+ | [Install Go](https://go.dev/dl/) |
+| tmux | any | Agent sessions run in tmux |
+| WireGuard | any | Optional — for P2P mode |
+| git | any | To clone the repo |
+
+## Installation
+
+### 1. Clone and Build
+
+```bash
+git clone https://github.com/fractalmind-ai/fractalmind-envd.git
+cd fractalmind-envd
+make build
+```
+
+This produces `./bin/envd`. For cross-compilation:
+
+```bash
+# Linux AMD64
+make build-linux
+
+# All platforms (Linux AMD64 + macOS ARM64)
+make build-all
+```
+
+### 2. Configure
+
+```bash
+cp sentinel.yaml.example sentinel.yaml
+```
+
+Edit `sentinel.yaml` with your settings (see [Configuration Reference](#configuration-reference) below).
+
+### 3. Run
+
+```bash
+./bin/envd --config sentinel.yaml
+```
+
+Or build and run in one step:
+
+```bash
+make run
+```
+
+To install system-wide:
+
+```bash
+sudo make install
+# Now available as: envd
+```
+
+## Configuration Reference
+
+The `sentinel.yaml` file controls all envd behavior. Here's every field explained:
+
+### Gateway
+
+```yaml
+gateway:
+  url: ws://localhost:8080/ws       # WebSocket URL of the Gateway server
+  reconnect_interval: 5s           # Wait time before reconnecting on disconnect
+```
+
+The Gateway is the WebSocket server that envd connects to for receiving remote commands in Gateway mode. This is the simpler deployment option that doesn't require SUI or WireGuard.
+
+### Identity
+
+```yaml
+identity:
+  host_id: ""        # Unique ID for this host. Auto-generated (UUID) if empty.
+  hostname: ""       # Human-readable name. Defaults to os.Hostname() if empty.
+```
+
+### Agents
+
+```yaml
+agents:
+  scan_method: tmux          # Discovery method: tmux | systemd | docker
+  scan_interval: 10s         # How often to scan for agents
+  auto_restart: true         # Auto-restart crashed agents
+  max_restart_attempts: 3    # Max restarts before alerting
+```
+
+- **scan_method**: How envd finds local agents. `tmux` scans for tmux sessions (recommended for FractalMind). `systemd` and `docker` are planned.
+- **auto_restart**: When enabled, envd detects agents that were running but disappeared from tmux and restarts them automatically.
+- **max_restart_attempts**: After this many failed restarts, envd sends an alert instead of retrying.
+
+### Heartbeat
+
+```yaml
+heartbeat:
+  interval: 30s    # How often to send heartbeat
+```
+
+In Gateway mode, heartbeat is sent via WebSocket. In P2P mode, heartbeat is sent directly via WireGuard (no on-chain cost).
+
+### SUI (Advanced)
+
+```yaml
+sui:
+  enabled: false
+  rpc: https://fullnode.testnet.sui.io:443
+  keypair_path: ~/.sui/envd.key       # Ed25519 keypair (auto-generated if missing)
+  package_id: "0x74aef8ff3bb0da5d5626780e6c0e5f1f36308a40580e519920fdc9204e73d958"
+  registry_id: "0xe557465293df033fd6ba1347706d7e9db2a35de4667a3b6a2e20252587b6e505"
+  org_id: "0x..."                     # Your Organization object ID
+  cert_id: "0x..."                    # Your AgentCertificate object ID
+  poll_interval: 30s                  # How often to poll for new peer events
+```
+
+When enabled, envd uses SUI blockchain for peer discovery and identity instead of relying on a central Gateway.
+
+### WireGuard (Advanced)
+
+```yaml
+wireguard:
+  enabled: false
+  interface_name: wg0
+  listen_port: 51820
+  keypair_path: ~/.wireguard/envd.key  # Curve25519 keypair (auto-generated)
+  # address: 10.100.X.Y/32             # Auto-assigned from SUI address hash if empty
+```
+
+When enabled alongside SUI, envd creates WireGuard P2P tunnels to other envd nodes discovered through SUI Events.
+
+### STUN (Advanced)
+
+```yaml
+stun:
+  enabled: false
+  servers:
+    - stun:stun.l.google.com:19302
+    - stun:stun1.l.google.com:19302
+```
+
+STUN discovers your public IP and port for NAT traversal. Only needed when envd nodes are behind NAT.
+
+## Deployment Modes
+
+### Gateway Mode (Simple)
+
+The simplest setup — envd connects to a central Gateway via WebSocket for command routing and heartbeat.
+
+```yaml
+# sentinel.yaml — Gateway mode
+gateway:
+  url: ws://your-gateway:8080/ws
+agents:
+  scan_method: tmux
+  auto_restart: true
+heartbeat:
+  interval: 30s
+# sui and wireguard remain disabled
+```
+
+**Pros:** Easy setup, no blockchain knowledge needed.
+**Cons:** Relies on a central Gateway server.
+
+### P2P Mode (Decentralized)
+
+Full decentralized mode — envd uses SUI for peer discovery and WireGuard for direct P2P communication. No central server required.
+
+```yaml
+# sentinel.yaml — P2P mode
+gateway:
+  url: ws://localhost:8080/ws    # Fallback only, not required
+agents:
+  scan_method: tmux
+  auto_restart: true
+heartbeat:
+  interval: 30s
+sui:
+  enabled: true
+  rpc: https://fullnode.testnet.sui.io:443
+  keypair_path: ~/.sui/envd.key
+  package_id: "0x74aef8ff3bb0da5d5626780e6c0e5f1f36308a40580e519920fdc9204e73d958"
+  registry_id: "0xe557465293df033fd6ba1347706d7e9db2a35de4667a3b6a2e20252587b6e505"
+  org_id: "0x..."    # Your org
+  cert_id: "0x..."   # Your agent certificate
+  poll_interval: 30s
+wireguard:
+  enabled: true
+  listen_port: 51820
+stun:
+  enabled: true
+```
+
+**Pros:** Fully decentralized, no single point of failure, on-chain auditability.
+**Cons:** Requires SUI keypair, AgentCertificate, and WireGuard setup.
+
+## Remote Commands
+
+Once envd is running, you can send commands through the Gateway (Gateway mode) or directly via WireGuard (P2P mode):
+
+### status
+
+List all agents running on the host.
+
+```
+→ status
+← { "agents": [
+     { "id": "agent-001", "session": "agent-001", "status": "running" },
+     { "id": "agent-002", "session": "agent-002", "status": "running" }
+   ]}
+```
+
+### restart
+
+Restart a specific agent by session name.
+
+```
+→ restart agent-001
+← { "message": "agent agent-001 restarted" }
+```
+
+### logs
+
+Get recent output from an agent's tmux session.
+
+```
+→ logs agent-001 [lines=100]
+← { "logs": "..." }
+```
+
+### kill
+
+Stop an agent's tmux session.
+
+```
+→ kill agent-001
+← { "message": "agent agent-001 killed" }
+```
+
+### shell
+
+Execute an arbitrary shell command on the host.
+
+```
+→ shell "df -h"
+← { "output": "..." }
+```
+
+## SUI + WireGuard Setup (Advanced)
+
+To enable the full decentralized P2P mode:
+
+### 1. Get a SUI Keypair
+
+envd auto-generates a keypair on first run if `keypair_path` doesn't exist. To create one manually:
+
+```bash
+mkdir -p ~/.sui
+# envd will generate ~/.sui/envd.key automatically
+```
+
+### 2. Obtain an AgentCertificate
+
+Your org admin needs to register your agent on-chain using the [fractalmind-protocol SDK](/protocol/sdk):
+
+```typescript
+import { FractalMindSDK } from '@anthropic-ai/fractalmind-sdk'
+
+const sdk = new FractalMindSDK({ network: 'testnet' })
+const cert = await sdk.registerAgent(orgId, {
+  name: 'envd-host-a',
+  address: '<your-sui-address>',
+})
+// cert.id → use as cert_id in sentinel.yaml
+```
+
+### 3. Install WireGuard
+
+```bash
+# Ubuntu/Debian
+sudo apt install wireguard
+
+# macOS
+brew install wireguard-tools
+```
+
+### 4. Configure and Run
+
+Update `sentinel.yaml` with SUI and WireGuard settings (see [P2P Mode](#p2p-mode-decentralized) above), then:
+
+```bash
+sudo ./bin/envd --config sentinel.yaml
+```
+
+::: tip
+`sudo` is needed for WireGuard interface creation. In Gateway-only mode, root is not required.
+:::
+
+### 5. Verify
+
+Check that envd registered on-chain:
+
+```bash
+# Query PeerRegistry for your node
+curl -s https://fullnode.testnet.sui.io:443 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "suix_queryEvents",
+    "params": [{"MoveEventType": "0x74aef8ff3bb0da5d5626780e6c0e5f1f36308a40580e519920fdc9204e73d958::peer::PeerRegistered"}],
+    "id": 1
+  }' | jq '.result.data'
+```
+
+## Troubleshooting
+
+### envd can't find agents
+
+- Verify tmux is installed: `tmux -V`
+- Check that agents are running as tmux sessions: `tmux list-sessions`
+- Ensure `scan_method` in config matches your setup
+
+### WebSocket connection keeps dropping
+
+- Verify Gateway URL is correct and reachable
+- Check firewall rules for the Gateway port
+- Increase `reconnect_interval` if the Gateway is under load
+
+### WireGuard tunnel not establishing
+
+- Verify WireGuard is installed: `wg --version`
+- Check that `listen_port` (default 51820) is open in firewall
+- Ensure STUN is enabled if nodes are behind NAT
+- Check envd logs for `[wg]` and `[stun]` entries
+
+### SUI registration fails
+
+- Verify SUI RPC endpoint is reachable
+- Check that `org_id` and `cert_id` are correct
+- Ensure the AgentCertificate is in `active` status
+- If self-paying: ensure your SUI address has balance (~0.01 SUI is enough)
+
+### Agent auto-restart not working
+
+- Check that `auto_restart: true` in config
+- Verify `max_restart_attempts` hasn't been exhausted (check logs for `max attempts reached`)
+- Ensure the agent's tmux session has a valid restart command
+
+## Next Steps
+
+- [envd Component Overview](/components/envd) — Architecture, SUI contracts, and competitive analysis
+- [Architecture Overview](/architecture/overview) — How envd fits into the FractalMind stack
+- [Protocol SDK](/protocol/sdk) — Register agents and orgs on-chain
+- [Testnet Deployment](/protocol/testnet) — Contract addresses and existing org data


### PR DESCRIPTION
## Summary
- Adds full **fractalmind-envd** documentation to the docs site (2 new pages, 558 lines)
- Updates sidebar navigation and components overview to include envd

## New Pages

### `docs/components/envd.md` — Component Overview
- What envd solves and why it exists
- Dual-plane architecture diagram (SUI control plane + WireGuard data plane)
- Connection flow (register → discover → P2P → NAT fallback)
- Core features: agent discovery, heartbeat, remote commands, self-healing
- Competitive comparison table: envd vs TeamViewer vs Tailscale
- SUI smart contracts: `peer.move` (PeerRegistry) + `sponsor.move` (Gas sponsorship)
- Testnet deployment IDs (Package, PeerRegistry, SponsorRegistry)
- Gas cost analysis: ~$0.14/month for 2 nodes, ~$7.13 for 100 nodes

### `docs/guide/envd-quickstart.md` — Setup Guide
- Prerequisites and installation steps (clone, build, configure, run)
- Full `sentinel.yaml` configuration reference with every field explained
- Two deployment modes: Gateway (simple) vs P2P (decentralized)
- Remote command reference with examples (status, restart, logs, kill, shell)
- Advanced SUI + WireGuard setup walkthrough
- Troubleshooting section

## Navigation Changes
- **Sidebar**: envd added to Components list; new "Setup Guides" group in Guide sidebar
- **Components overview**: envd moved from "Planned" to "Core Components" table

## Files Changed
- `docs/components/envd.md` — New (component documentation)
- `docs/guide/envd-quickstart.md` — New (quickstart guide)
- `docs/.vitepress/config.ts` — Sidebar updates
- `docs/components/overview.md` — envd moved to Core Components

## Test plan
- [ ] Verify `npm run docs:build` passes (confirmed locally)
- [ ] Check envd component page renders with all sections
- [ ] Check envd quickstart renders with code blocks and config examples
- [ ] Verify sidebar shows envd under Components and Setup Guides under Guide
- [ ] Verify components overview table includes envd with correct link
- [ ] Confirm all internal links resolve (/components/protocol, /architecture/overview, etc.)
- [ ] Existing pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)