### PR TITLE
chore: repo packaging — README, LICENSE, CONTRIBUTING, templates (#9)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a broken page, link, or rendering issue
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear description of what's broken.
+
+## Page URL
+
+Link to the affected page (e.g., https://fractalmind-ai.github.io/guide/quick-start).
+
+## Expected Behavior
+
+What should happen instead.
+
+## Screenshots
+
+If applicable, add screenshots showing the issue.
+
+## Environment
+
+- Browser: [e.g., Chrome 120]
+- Device: [e.g., Desktop / Mobile]
+- OS: [e.g., macOS 14]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest new content, pages, or site improvements
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Description
+
+What do you want to see added or changed?
+
+## Motivation
+
+Why is this useful? What problem does it solve?
+
+## Proposed Solution
+
+If you have ideas on how to implement this, describe them here.
+
+## Additional Context
+
+Any other information, mockups, or references.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to FractalMind AI Docs
+
+Thanks for your interest in contributing! This repo powers the documentation site at https://fractalmind-ai.github.io.
+
+## Getting Started
+
+```bash
+git clone https://github.com/fractalmind-ai/fractalmind-ai.github.io.git
+cd fractalmind-ai.github.io
+npm ci
+npm run docs:dev
+```
+
+## How to Contribute
+
+### Documentation Changes
+
+1. Fork the repo and create a branch: `git checkout -b docs/my-change`
+2. Edit or add Markdown files in `docs/`
+3. Run `npm run docs:build` to verify no build errors
+4. Submit a PR with a clear description of what changed and why
+
+### Page Structure
+
+- `docs/guide/` — Getting started guides
+- `docs/architecture/` — System architecture docs
+- `docs/components/` — Individual component documentation
+- `docs/protocol/` — SUI smart contract and SDK docs
+- `docs/roadmap/` — Project roadmap
+
+### Writing Guidelines
+
+- Keep protocol behavior docs synchronized with the Move contracts and SDK
+- For any API or state-machine change, update docs in the same PR
+- Include runnable examples whenever adding new flows
+- Prefer concise diagrams (Mermaid or ASCII) for lifecycle and authorization changes
+- Use VitePress [Markdown Extensions](https://vitepress.dev/guide/markdown) where helpful (e.g., `::: tip`, code groups)
+
+### Custom Theme
+
+The site uses a custom VitePress theme located in `docs/.vitepress/theme/`. If you're modifying the landing page or visual components:
+
+- `docs/.vitepress/theme/components/BrandHome.vue` — Landing page
+- `docs/.vitepress/theme/custom.css` — Global style overrides
+- `docs/.vitepress/config.ts` — Navigation and sidebar config
+
+## PR Guidelines
+
+- One topic per PR
+- Include a clear title and description
+- Verify `npm run docs:build` passes before submitting
+- If adding a new page, update the sidebar config in `docs/.vitepress/config.ts`
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/fractalmind-ai/fractalmind-ai.github.io/issues) with the appropriate template:
+- **Bug Report** — for broken pages, links, or rendering issues
+- **Feature Request** — for new content or site improvements
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 FractalMind AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,80 @@
-# FractalMind Docs Site
+<div align="center">
 
-VitePress documentation site for the FractalMind ecosystem.
+# FractalMind AI — Documentation Site
 
-## Prerequisites
+**Open-source framework for organizing AI agent teams with structured workflows, goal tracking, and on-chain governance on SUI.**
 
-- Node.js 20+
-- npm 10+
+[![Docs](https://img.shields.io/badge/docs-fractalmind--ai.github.io-4DA2FF)](https://fractalmind-ai.github.io)
+[![GitHub Org](https://img.shields.io/badge/GitHub-fractalmind--ai-181717?logo=github)](https://github.com/fractalmind-ai)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![VitePress](https://img.shields.io/badge/VitePress-1.6-646CFF?logo=vite)](https://vitepress.dev)
 
-## Local Development
+</div>
+
+---
+
+## What is FractalMind?
+
+FractalMind helps teams organize AI agents into structured, collaborative workflows. It uses the same self-similar pattern at every level — from individual agents to multi-team organizations — with identity and governance recorded on SUI blockchain.
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Organization (SUI)              │
+│                fractalmind-protocol              │
+├────────────┬───────────────┬────────────────────┤
+│  Team A    │    Team B     │     Team C          │
+│  team-mgr  │   team-mgr   │    team-mgr         │
+├────┬───────┼────┬──────────┼────┬───────────────┤
+│ Agent│Agent │Agent│  Agent  │Agent│    Agent      │
+│ a-mgr│a-mgr│a-mgr│  a-mgr │a-mgr│    a-mgr     │
+└────┴───────┴────┴──────────┴────┴───────────────┘
+        ▲              ▲              ▲
+   fractalbot     okr-manager     envd (remote)
+   (messaging)    (goal tracking) (WireGuard P2P)
+```
+
+## Quick Start
 
 ```bash
+# Clone and install
+git clone https://github.com/fractalmind-ai/fractalmind-ai.github.io.git
+cd fractalmind-ai.github.io
 npm ci
+
+# Start local dev server
 npm run docs:dev
-```
 
-## Build and Preview
-
-```bash
+# Build for production
 npm run docs:build
-npm run docs:preview
 ```
 
-## Deployment
+Then open http://localhost:5173 to browse the docs locally.
 
-- GitHub Pages deploy is managed by `.github/workflows/deploy.yml`.
-- Deploys on pushes to `main`.
+## Links
+
+| Resource | URL |
+|----------|-----|
+| Documentation | https://fractalmind-ai.github.io |
+| Live Explorer | https://fractalmind-ai.github.io/explorer |
+| GitHub Org | https://github.com/fractalmind-ai |
+| Protocol (SUI Testnet) | `0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24` |
+
+## Core Components
+
+| Component | Description | Repo |
+|-----------|-------------|------|
+| **fractalmind-protocol** | SUI Move smart contracts | [GitHub](https://github.com/fractalmind-ai/fractalmind-protocol) |
+| **fractalmind-envd** | Remote agent management (WireGuard + SUI) | [GitHub](https://github.com/fractalmind-ai/fractalmind-envd) |
+| **fractalbot** | Multi-channel messaging bridge | [GitHub](https://github.com/fractalmind-ai/fractalbot) |
+| **agent-manager** | Agent lifecycle management (tmux) | [GitHub](https://github.com/fractalmind-ai/agent-manager-skill) |
+| **team-manager** | Multi-agent team orchestration | [GitHub](https://github.com/fractalmind-ai/team-manager-skill) |
+| **okr-manager** | Goal tracking for AI teams | [GitHub](https://github.com/fractalmind-ai/okr-manager-skill) |
+| **explorer** | On-chain org visualization (D3.js) | [GitHub](https://github.com/fractalmind-ai/explorer) |
 
 ## Contributing
 
-1. Keep protocol behavior docs synchronized with the Move contracts and SDK.
-2. For any API/state-machine change, update docs in the same PR.
-3. Include runnable examples whenever adding new flows.
-4. Prefer concise diagrams for lifecycle and authorization changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
Adds standard open-source repo packaging: rewritten README, MIT license, contributing guide, and GitHub issue templates.

Closes #9

## Files

| File | Description |
|------|-------------|
| `README.md` | Rewritten with project overview, ASCII architecture diagram, quick start (3 commands), component table, badges |
| `LICENSE` | MIT license |
| `CONTRIBUTING.md` | Dev setup, page structure, writing guidelines, PR rules |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug report template |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature request template |

## Test plan
- [ ] README renders correctly on GitHub with badges, architecture diagram, and tables
- [ ] LICENSE recognized by GitHub as MIT
- [ ] Issue templates appear when creating new issues
- [ ] CONTRIBUTING.md linked from README
- [ ] `npm run docs:build` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)