### PR TITLE
docs: reframe public site around FractalMind OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ FractalMind has moved beyond a pure **protocol-first** story. The current focus 
 
 - **heartbeat-driven coordination**
 - **structured memory and durable runtime state**
-- **governed autonomy with human veto on irreversible actions**
+- **governed autonomy through human–AI co-creation, not human bottlenecks**
 - **reviewable delivery with evidence, QA, and outcome tracking**
 - **public trust surfaces when on-chain guarantees matter**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # FractalMind AI — Documentation Site
 
-**Open-source framework for organizing AI agent teams with structured workflows, goal tracking, and on-chain governance on SUI.**
+**Heartbeat-driven operating system for AI agent teams.**
+
+*Open-source infrastructure for governed autonomy, structured memory, multi-channel execution, and optional on-chain trust surfaces.*
 
 [![Docs](https://img.shields.io/badge/docs-fractalmind--ai.github.io-4DA2FF)](https://fractalmind-ai.github.io)
 [![GitHub Org](https://img.shields.io/badge/GitHub-fractalmind--ai-181717?logo=github)](https://github.com/fractalmind-ai)
@@ -15,23 +17,54 @@
 
 ## What is FractalMind?
 
-FractalMind helps teams organize AI agents into structured, collaborative workflows. It uses the same self-similar pattern at every level — from individual agents to multi-team organizations — with identity and governance recorded on SUI blockchain.
+FractalMind AI is an **OS-first stack for running AI agent teams**.
+
+The current operating core is not just an on-chain protocol. It is a heartbeat-driven control loop that turns messy multi-agent work into a repeatable system:
 
 ```
-┌─────────────────────────────────────────────────┐
-│                  Organization (SUI)              │
-│                fractalmind-protocol              │
-├────────────┬───────────────┬────────────────────┤
-│  Team A    │    Team B     │     Team C          │
-│  team-mgr  │   team-mgr   │    team-mgr         │
-├────┬───────┼────┬──────────┼────┬───────────────┤
-│ Agent│Agent │Agent│  Agent  │Agent│    Agent      │
-│ a-mgr│a-mgr│a-mgr│  a-mgr │a-mgr│    a-mgr     │
-└────┴───────┴────┴──────────┴────┴───────────────┘
-        ▲              ▲              ▲
-   fractalbot     okr-manager     envd (remote)
-   (messaging)    (goal tracking) (WireGuard P2P)
+signal -> memory -> candidate OKR -> governance -> execution -> outcome -> evolution
 ```
+
+That loop is currently realized through:
+
+- **`oh-my-code`** — reference workspace where the control loop runs
+- **`agent-manager`** — execution plane for tmux-based agents
+- **`fractalbot`** — multi-channel routing for humans and agents
+- **`fractalmind-okrs`** — shared candidate-OKR publication surface
+- **`fractalmind-protocol`** — optional SUI trust layer for identity and governance
+
+## Current Focus
+
+FractalMind has moved beyond a pure **protocol-first** story. The current focus is:
+
+- **heartbeat-driven coordination**
+- **structured memory and durable runtime state**
+- **governed autonomy with human veto on irreversible actions**
+- **reviewable delivery with evidence, QA, and outcome tracking**
+- **public trust surfaces when on-chain guarantees matter**
+
+## Public Surfaces
+
+| Surface | URL | Purpose |
+|--------|-----|---------|
+| Documentation | https://fractalmind-ai.github.io | Public docs for the stack and operating model |
+| GitHub Org | https://github.com/fractalmind-ai | Source of truth for the 18 public repos |
+| Explorer | https://fractalmind-ai.github.io/explorer | Visualization / trust surface |
+| Candidate OKRs | https://github.com/fractalmind-ai/fractalmind-okrs | Shared publication surface for candidate OKRs |
+| Protocol (SUI Testnet) | `0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24` | Optional on-chain trust layer |
+
+## Repository Map
+
+FractalMind AI currently spans **18 repositories** across four surfaces:
+
+1. **OS kernel & governance**
+   - `oh-my-code`, `fractalmind-okrs`, `.github`, `agent-manager-skill`, `team-manager-skill`, `okr-manager-skill`
+2. **Execution & collaboration interfaces**
+   - `fractalbot`, `team-chat-skill`, `use-fractalbot-skill`, `agent-browser-skill`, `use-phone-skill`, `turbo-frequency-skill`
+3. **Protocol & runtime**
+   - `fractalmind-protocol`, `fractalmind-envd`, `explorer`, `openclaw-gateway-app`
+4. **Applications & distribution**
+   - `fractalmind-ai.github.io`, `typemind-android`
 
 ## Quick Start
 
@@ -50,26 +83,12 @@ npm run docs:build
 
 Then open http://localhost:5173 to browse the docs locally.
 
-## Links
+## Learn More
 
-| Resource | URL |
-|----------|-----|
-| Documentation | https://fractalmind-ai.github.io |
-| Live Explorer | https://fractalmind-ai.github.io/explorer |
-| GitHub Org | https://github.com/fractalmind-ai |
-| Protocol (SUI Testnet) | `0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24` |
-
-## Core Components
-
-| Component | Description | Repo |
-|-----------|-------------|------|
-| **fractalmind-protocol** | SUI Move smart contracts | [GitHub](https://github.com/fractalmind-ai/fractalmind-protocol) |
-| **fractalmind-envd** | Remote agent management (WireGuard + SUI) | [GitHub](https://github.com/fractalmind-ai/fractalmind-envd) |
-| **fractalbot** | Multi-channel messaging bridge | [GitHub](https://github.com/fractalmind-ai/fractalbot) |
-| **agent-manager** | Agent lifecycle management (tmux) | [GitHub](https://github.com/fractalmind-ai/agent-manager-skill) |
-| **team-manager** | Multi-agent team orchestration | [GitHub](https://github.com/fractalmind-ai/team-manager-skill) |
-| **okr-manager** | Goal tracking for AI teams | [GitHub](https://github.com/fractalmind-ai/okr-manager-skill) |
-| **explorer** | On-chain org visualization (D3.js) | [GitHub](https://github.com/fractalmind-ai/explorer) |
+- [What is FractalMind?](docs/guide/what-is-fractalmind.md)
+- [Architecture Overview](docs/architecture/overview.md)
+- [Components Overview](docs/components/overview.md)
+- [Roadmap](docs/roadmap/index.md)
 
 ## Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
   title: 'FractalMind AI',
-  description: 'Organize AI Agents into Fractal Structures. Emerge Superintelligence.',
+  description: 'Heartbeat-driven operating system for AI agent teams.',
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
   ],

--- a/docs/.vitepress/theme/components/BrandHome.vue
+++ b/docs/.vitepress/theme/components/BrandHome.vue
@@ -3,85 +3,85 @@ import { ref, onMounted } from 'vue'
 
 const products = [
   {
+    name: 'oh-my-code',
+    description: 'Reference workspace where the heartbeat-driven FractalMind OS runs: memory, OKRs, governance, dispatch, and outcomes.',
+    icon: '&#x267b;',
+    color: '#4DA2FF',
+    link: 'https://github.com/fractalmind-ai/oh-my-code',
+  },
+  {
+    name: 'fractalmind-okrs',
+    description: 'Shared publication surface for candidate OKRs, portfolio review, and durable strategic memory.',
+    icon: '&#x1f4ca;',
+    color: '#e94560',
+    link: 'https://github.com/fractalmind-ai/fractalmind-okrs',
+  },
+  {
+    name: 'fractalbot',
+    description: 'Multi-channel messaging bridge that routes humans and agents across Slack, Telegram, Discord, Feishu, and more.',
+    icon: '&#x1f4e1;',
+    color: '#4ecdc4',
+    link: '/components/fractalbot',
+  },
+  {
+    name: 'agent-manager',
+    description: 'Execution plane for tmux-based agents with lifecycle management, monitoring, and dispatch support.',
+    icon: '&#x1f916;',
+    color: '#4ecdc4',
+    link: '/components/agent-manager',
+  },
+  {
     name: 'fractalmind-protocol',
-    description: 'SUI Move smart contracts for on-chain AI org identity, governance, and task management.',
+    description: 'Optional trust layer on SUI for identity, governance, and organization primitives when on-chain guarantees matter.',
     icon: '&#x26d3;',
     color: '#4DA2FF',
     link: '/components/protocol',
   },
   {
     name: 'fractalmind-envd',
-    description: 'Decentralized agent remote management with WireGuard tunnels and SUI-based authorization.',
+    description: 'Go runtime for remote and distributed execution beyond a single machine.',
     icon: '&#x1f310;',
     color: '#4ecdc4',
-    link: '/components/overview',
-  },
-  {
-    name: 'fractalbot',
-    description: 'Multi-channel messaging bridge — iMessage, Telegram, Slack, Discord, and Feishu in one gateway.',
-    icon: '&#x1f4e1;',
-    color: '#e94560',
-    link: '/components/fractalbot',
-  },
-  {
-    name: 'agent-manager',
-    description: 'AI agent lifecycle management with tmux-based sessions, heartbeat monitoring, and auto-restart.',
-    icon: '&#x1f916;',
-    color: '#4ecdc4',
-    link: '/components/agent-manager',
-  },
-  {
-    name: 'team-manager',
-    description: 'Multi-agent team orchestration with lead-based coordination and workflow definitions.',
-    icon: '&#x1f465;',
-    color: '#4DA2FF',
-    link: '/components/team-manager',
-  },
-  {
-    name: 'okr-manager',
-    description: 'Goal tracking for AI teams — objectives, key results, quality gates, and progress monitoring.',
-    icon: '&#x1f3af;',
-    color: '#e94560',
-    link: '/components/okr-manager',
+    link: '/components/envd',
   },
   {
     name: 'explorer',
-    description: 'On-chain organization visualization with D3.js — browse orgs, agents, and tasks on SUI.',
+    description: 'Public visualization surface for organizations, components, and trust-critical state.',
     icon: '&#x1f50d;',
-    color: '#4ecdc4',
+    color: '#e94560',
     link: 'https://fractalmind-ai.github.io/explorer',
   },
 ]
 
 const stats = [
-  { value: '12+', label: 'AI Agents' },
-  { value: '6', label: 'Active Teams' },
-  { value: '7', label: 'Core Components' },
-  { value: 'Live', label: 'SUI Testnet' },
+  { value: '18', label: 'Public Repositories' },
+  { value: '14', label: 'Local Checkouts' },
+  { value: '100%', label: 'Closed-Loop Delivery' },
+  { value: 'Live', label: 'Heartbeat Control Loop' },
 ]
 
 const milestones = [
-  { date: '2025 Q4', title: 'Core Protocol Shipped', description: 'fractalmind-protocol deployed to SUI Testnet with 9 Move modules.' },
-  { date: '2026 Q1', title: 'Agent Infrastructure', description: 'agent-manager, team-manager, OKR tracking, and fractalbot all production-ready.' },
-  { date: '2026 Q1', title: '12+ Agents Running', description: 'SuLabs org operating with 12 AI agents across 6 teams, completing real tasks.' },
-  { date: '2026 Q1', title: 'envd Decentralized Management', description: 'WireGuard P2P + SUI identity for remote agent management — no central server.' },
-  { date: '2026 Q1', title: 'Explorer & Docs Site', description: 'On-chain org visualizer and full documentation site launched.' },
+  { date: '2025 Q4', title: 'Protocol trust layer validated', description: 'fractalmind-protocol shipped to SUI Testnet as the optional trust surface.' },
+  { date: '2026 Q1', title: 'FractalMind OS control loop aligned', description: 'SOUL, HEARTBEAT, runtime memory, and heartbeat execution now share one operating model.' },
+  { date: '2026 Q1', title: 'Candidate OKR sync live', description: 'Strategic candidates now publish through fractalmind-okrs instead of staying trapped in one terminal.' },
+  { date: '2026 Q1', title: 'Multi-channel execution running', description: 'fractalbot + agent-manager route humans to agents and keep delivery observable.' },
+  { date: '2026 Q1', title: 'Public surfaces being re-aligned', description: 'Docs and GitHub are being updated from a protocol-first story to the current OS-first reality.' },
 ]
 
 const githubLinks = [
   {
-    label: '13+ Repositories',
-    description: 'Protocol, agents, messaging, tools — all open source under MIT.',
+    label: '18 Repositories',
+    description: 'Browse the full OS kernel, execution surfaces, protocol, and application repos.',
     url: 'https://github.com/fractalmind-ai',
   },
   {
-    label: 'On-Chain Proof',
-    description: 'Verify the protocol contract and transactions live on SUI Testnet.',
-    url: 'https://suiscan.xyz/testnet/object/0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24',
+    label: 'Candidate OKR Portfolio',
+    description: 'See the shared strategy surface in fractalmind-okrs.',
+    url: 'https://github.com/fractalmind-ai/fractalmind-okrs',
   },
   {
     label: 'Live Explorer',
-    description: 'Browse the SuLabs organization — agents, teams, and tasks on-chain.',
+    description: 'Inspect the public visualization / trust surface.',
     url: 'https://fractalmind-ai.github.io/explorer',
   },
 ]
@@ -121,32 +121,32 @@ onMounted(() => {
         </div>
         <h1 class="hero-title">
           <span class="title-main">FractalMind AI</span>
-          <span class="title-sub">Organize AI agent teams that actually ship</span>
+          <span class="title-sub">Heartbeat-driven operating system for AI agent teams</span>
         </h1>
         <p class="hero-description">
-          Open-source framework for running multi-agent teams with structured
-          workflows, goal tracking, and on-chain governance on SUI.
+          Open-source operating system for governed autonomy, structured memory,
+          multi-channel execution, and optional on-chain trust surfaces.
         </p>
         <div class="hero-selling-points">
           <div class="selling-point">
             <span class="sp-icon">&#x1f465;</span>
             <div>
-              <strong>For teams deploying AI agents</strong>
-              <p>Manage 1 to 100+ agents with lead-based coordination, OKR tracking, and auto-restart.</p>
+              <strong>Heartbeat-driven execution</strong>
+              <p>Run delivery through a repeatable loop: signal, memory, candidate OKR, governance, execution, and outcome.</p>
             </div>
           </div>
           <div class="selling-point">
             <span class="sp-icon">&#x1f9e9;</span>
             <div>
-              <strong>Composable, not monolithic</strong>
-              <p>Pick only the modules you need — agent management, messaging, team orchestration, or the full stack.</p>
+              <strong>Governed autonomy</strong>
+              <p>Low-risk work can move automatically, while production, money, and public actions stay behind human approval.</p>
             </div>
           </div>
           <div class="selling-point">
             <span class="sp-icon">&#x1f50d;</span>
             <div>
-              <strong>See it running live</strong>
-              <p>Browse the SuLabs organization on SUI Testnet — 12+ agents, 6 teams, real tasks being completed.</p>
+              <strong>Protocol when trust matters</strong>
+              <p>Use SUI and public visualization surfaces when identity, governance, or trust-critical proof is required — without making that the whole story.</p>
             </div>
           </div>
         </div>
@@ -180,20 +180,18 @@ onMounted(() => {
           <div class="ps-card problem">
             <h3>The Problem</h3>
             <p>
-              AI agent systems today are opaque, centralized, and fragile. There's no standard
-              way to verify agent identity, coordinate multi-agent teams, or govern autonomous
-              operations transparently. As organizations deploy more AI agents, they need
-              infrastructure that scales without sacrificing trust.
+              Most AI stacks stop at chat, tools, or single-agent orchestration. Real operations
+              still leak through ad hoc memory, manual follow-up, and unclear ownership. As the
+              number of agents grows, teams need a repeatable operating system — not just another framework.
             </p>
           </div>
           <div class="ps-card solution">
             <h3>The Solution</h3>
             <p>
-              FractalMind uses <strong>fractal architecture</strong> — the same self-similar
-              pattern at every level — combined with <strong>on-chain governance on SUI</strong>.
-              Agent identity, team structure, task assignment, and organizational hierarchy all
-              live on-chain. The only AI management system where governance is fully
-              permissionless and auditable.
+              FractalMind now centers on a <strong>heartbeat-driven OS</strong>: structured memory,
+              candidate OKRs, governed autonomy, agent dispatch, and outcome tracking. The
+              protocol and explorer remain valuable trust surfaces, but the daily system runs
+              through an OS-first control loop instead of a protocol-only story.
             </p>
           </div>
         </div>
@@ -203,8 +201,8 @@ onMounted(() => {
     <!-- Product Matrix -->
     <section class="products-section">
       <div class="section-container">
-        <h2 class="section-title">Core Components</h2>
-        <p class="section-subtitle">Seven composable modules — install only what you need</p>
+        <h2 class="section-title">Core Operating Surfaces</h2>
+        <p class="section-subtitle">The current system is OS-first: communication, execution, governance, and trust surfaces.</p>
         <div class="products-grid">
           <a
             v-for="product in products"
@@ -226,8 +224,8 @@ onMounted(() => {
     <!-- Architecture Diagram -->
     <section class="architecture-section">
       <div class="section-container">
-        <h2 class="section-title">Fractal Architecture</h2>
-        <p class="section-subtitle">Self-similar patterns at every layer</p>
+        <h2 class="section-title">Current Operating Stack</h2>
+        <p class="section-subtitle">Heartbeat-driven coordination with optional on-chain trust layers.</p>
         <div class="arch-diagram">
           <svg viewBox="0 0 800 420" fill="none" class="arch-svg">
             <!-- Background grid dots -->
@@ -314,8 +312,8 @@ onMounted(() => {
     <!-- Live Demo -->
     <section class="demo-section">
       <div class="section-container">
-        <h2 class="section-title">Live Demo</h2>
-        <p class="section-subtitle">Browse the FractalMind organization on SUI Testnet</p>
+        <h2 class="section-title">Public Surfaces</h2>
+        <p class="section-subtitle">Docs, GitHub, and Explorer show the public side of the system.</p>
         <div class="demo-card">
           <div class="demo-preview">
             <svg viewBox="0 0 600 300" fill="none" class="demo-svg">
@@ -378,11 +376,11 @@ onMounted(() => {
             </svg>
           </div>
           <div class="demo-info">
-            <h3>On-Chain Organization Explorer</h3>
+            <h3>Explorer + Open Documentation</h3>
             <p>
-              Visualize the full FractalMind organization hierarchy on SUI Testnet.
-              Browse teams, agents, tasks, and governance structures — all
-              read directly from the blockchain.
+              The explorer remains a public trust and visualization surface. It complements the
+              docs, GitHub organization, and operating-system narrative by showing a verifiable
+              public side of the stack.
             </p>
             <ul class="demo-features">
               <li>Interactive D3.js force-directed graph</li>
@@ -402,9 +400,9 @@ onMounted(() => {
     <section class="trust-section">
       <div class="section-container">
         <div class="trust-header">
-          <div class="stage-badge">Alpha</div>
+          <div class="stage-badge">OS v1.0</div>
           <h2 class="section-title">Trust &amp; Transparency</h2>
-          <p class="section-subtitle">Everything is open source, on-chain, and verifiable</p>
+          <p class="section-subtitle">Open source, file-backed, and publicly inspectable.</p>
         </div>
 
         <div class="trust-grid">
@@ -442,11 +440,12 @@ onMounted(() => {
             </div>
 
             <div class="stage-info">
-              <h4>Project Stage: Alpha</h4>
+              <h4>Project Stage: Operating-system rollout</h4>
               <p>
-                FractalMind is in active development. The core protocol is deployed on
-                SUI Testnet, and the agent infrastructure is running in production at
-                SuLabs. We ship openly — check the commit history.
+                FractalMind is actively shifting from a protocol-first public story to the
+                current OS-first reality: heartbeat, structured memory, candidate OKRs,
+                governed execution, and observable outcomes. The protocol is still live on
+                SUI Testnet — it is now one important surface inside a broader operating system.
               </p>
             </div>
           </div>
@@ -458,8 +457,8 @@ onMounted(() => {
     <section class="cta-section">
       <div class="section-container">
         <div class="cta-content">
-          <h2>Ready to build?</h2>
-          <p>Dive into the documentation or explore the source code on GitHub.</p>
+          <h2>Ready to run agent teams?</h2>
+          <p>Start with the docs, inspect the public repos, and follow the operating model all the way down.</p>
           <div class="cta-actions">
             <a href="/guide/quick-start" class="btn btn-primary">
               Quick Start Guide
@@ -491,7 +490,7 @@ onMounted(() => {
               </svg>
               <span>FractalMind AI</span>
             </div>
-            <p class="footer-tagline">Fractal Intelligence, On-Chain Governance</p>
+            <p class="footer-tagline">Governed autonomy for AI agent teams</p>
           </div>
           <div class="footer-links">
             <h4>Documentation</h4>

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,105 +1,107 @@
 # Architecture Overview
 
-FractalMind AI is organized into four layers, each responsible for a different level of abstraction.
+FractalMind AI is currently best understood as a **heartbeat-driven operating system for AI agent teams**, with optional on-chain trust surfaces.
 
-## Full Architecture
+## Current Operating Stack
 
 ```
-                 ┌─────────────────────────┐
-                 │   Users / Human Admins   │
-                 │  (Telegram/Slack/CLI)    │
-                 └───────────┬─────────────┘
-                             │
-                 ┌───────────▼─────────────┐
-                 │       fractalbot        │  Communication Layer
-                 │  Multi-channel gateway  │  Go · TG · Slack · Discord
-                 │                         │  Feishu · iMessage
-                 └───────────┬─────────────┘
-                             │ Route + context injection
-                 ┌───────────▼─────────────┐
-                 │     agent-manager       │  Management Layer (L0)
-                 │  Agent lifecycle (tmux) │  start · stop · heartbeat
-                 └─────┬───────────┬───────┘
-                       │           │
-          ┌────────────▼──┐  ┌────▼──────────┐
-          │ team-manager  │  │ okr-manager   │  Management Layer (L1)
-          │ Team orchestr │  │ Goal tracking │
-          └───────┬───────┘  └──────────────┘
-                  │
-          ┌───────▼───────────────────────┐
-          │         team-chat             │  Collaboration Layer
-          │  File messaging · Audit trail │
-          └───────────────────────────────┘
+                   ┌──────────────────────────────┐
+                   │    Humans / External Tools   │
+                   │   Slack · Telegram · CLI     │
+                   └──────────────┬───────────────┘
+                                  │
+                        ┌─────────▼─────────┐
+                        │    fractalbot     │  Communication surface
+                        │ routing + context │
+                        └─────────┬─────────┘
+                                  │
+               ┌──────────────────▼──────────────────┐
+               │         FractalMind OS core         │
+               │   oh-my-code + heartbeat control    │
+               │ signal -> memory -> OKR -> outcome  │
+               └───────┬───────────────┬─────────────┘
+                       │               │
+          ┌────────────▼───────┐   ┌───▼──────────────────┐
+          │   structured state │   │  fractalmind-okrs    │
+          │ memory/*.json*     │   │ candidate publication │
+          └────────────┬───────┘   └──────────────────────┘
+                       │
+               ┌───────▼────────┐
+               │ agent-manager  │  Execution plane
+               │ tmux lifecycle │
+               └───────┬────────┘
+                       │
+               ┌───────▼────────┐
+               │  Agent sessions │
+               │ main / coder-*  │
+               └─────────────────┘
 
-                 ═══ On-chain (SUI) ═══
-
-          ┌───────────────────────────────┐
-          │   fractalmind-protocol        │  Protocol Layer (L2)
-          │  Org · Agent · Task · DAO     │  Move contracts + TS SDK
-          └───────────────────────────────┘
-
-                 ═══ Future ═══
-
-          ┌───────────────────────────────┐
-          │   fractalmind-envd + Gateway  │  Execution Layer
-          │  On-chain ↔ off-chain bridge  │  Go daemon + TS service
-          └───────────────────────────────┘
+      Optional trust / distribution surfaces:
+      fractalmind-protocol · fractalmind-envd · explorer · openclaw-gateway-app
 ```
 
 ## Layer Responsibilities
 
-### Communication Layer — fractalbot
+### Communication Surface — `fractalbot`
 
-The entry point for human-to-agent communication. fractalbot is a Go binary that routes messages from external channels (Telegram, Slack, Discord, Feishu, iMessage) to the appropriate agent.
+Routes humans and agents across channels, injects routing context, and acts as the boundary between outside requests and the internal operating loop.
 
-### Management Layer — agent-manager, team-manager, okr-manager
+### Operating System Core — `oh-my-code` + heartbeat
 
-The operational core. These skills run as part of an AI agent's context and provide:
-- **agent-manager** (L0): Start, stop, monitor individual agents in tmux sessions
-- **team-manager** (L1): Coordinate multi-agent teams with a lead-based model
-- **okr-manager**: Track objectives and key results across agents and teams
+The current center of gravity. This is where the system:
 
-### Collaboration Layer — team-chat
+- records signals
+- reduces state into priorities
+- manages candidate OKRs
+- governs actions by risk level
+- dispatches work to agents
+- records outcomes and evolution
 
-Asynchronous, file-backed messaging between agents. Append-only inboxes, task state snapshots, and audit trails — all stored as local files.
+### Execution Plane — `agent-manager`
 
-### Protocol Layer — fractalmind-protocol
+Runs agents in tmux sessions, handles lifecycle management, and provides the actual execution plane for work chosen by the heartbeat.
 
-On-chain organizational primitives on SUI:
-- **Organization**: Create and manage AI organizations
-- **AgentCertificate**: On-chain agent identity with reputation
-- **Task**: Full lifecycle (create → assign → submit → verify → complete)
-- **Governance**: DAO proposals, voting, execution
-- **Fractal**: Nested sub-organizations with the same structure
+### Shared Governance Surface — `fractalmind-okrs`
 
-### Execution Layer — fractalmind-envd (Future)
+Stores exported candidate OKRs so strategy stays visible, reviewable, and durable beyond a single terminal session.
 
-A daemon that bridges on-chain governance with off-chain execution. When a DAO vote passes to upgrade an agent, envd carries out the action on the target machine.
+### Trust & Distribution Surfaces — `fractalmind-protocol`, `fractalmind-envd`, `explorer`
 
-## Component Dependencies
+These remain important, but they are now part of a broader system story:
+
+- **`fractalmind-protocol`** — optional on-chain identity / governance / trust layer on SUI
+- **`fractalmind-envd`** — remote execution and distributed runtime direction
+- **`explorer`** — public visualization surface
+
+## Dependency Shape
 
 ```
-fractalmind-protocol (standalone, on-chain)
+fractalmind-protocol (optional trust layer)
     │
-    └──▸ [future] Gateway Service (TS)
-              │
-              └──▸ [future] fractalmind-envd (Go daemon)
+    ├──▸ explorer
+    └──▸ [future] envd / gateway integration
 
-fractalbot (standalone, communication gateway)
+fractalbot
     │
-    ├──▸ agent-manager-skill (routes to agents)
-    │         │
-    │         ├──▸ team-manager-skill (depends on agent-manager)
-    │         │
-    │         ├──▸ okr-manager-skill (standalone, called by heartbeat)
-    │         │
-    │         └──▸ team-chat-skill (standalone, integrated by team-manager)
-    │
-    └──▸ use-fractalbot-skill (agent-side sending)
-
-oh-my-code (reference implementation, integrates all above)
+    └──▸ oh-my-code heartbeat
+             │
+             ├──▸ memory/*.json*
+             ├──▸ fractalmind-okrs
+             └──▸ agent-manager
+                      │
+                      ├──▸ team-manager
+                      ├──▸ okr-manager
+                      └──▸ team-chat / tool skills
 ```
 
-## Key Design Decisions
+## The Architectural Shift
 
-See [Design Decisions](/architecture/design-decisions) for the rationale behind major technical choices.
+The older public framing emphasized **protocol-first infrastructure on SUI**.
+
+The current reality is broader:
+
+- the protocol is still real and valuable
+- but the system that runs every day is a **governed execution OS**
+- heartbeat, memory, OKRs, routing, and outcomes are now the main operational story
+
+That is the architecture the public docs should describe.

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -1,60 +1,74 @@
 # Components Overview
 
-FractalMind AI consists of 13 repositories organized into four categories.
+FractalMind AI currently spans **18 repositories** organized into four operating surfaces.
 
-## Core Components
+## 1. OS Kernel & Governance
 
-These are the essential building blocks of the FractalMind stack.
+These repositories define how the system discovers work, governs action, and records durable state.
 
-| Component | Repo | Language | Role | Status |
-|-----------|------|----------|------|--------|
-| [fractalmind-protocol](/components/protocol) | [GitHub](https://github.com/fractalmind-ai/fractalmind-protocol) | Move + TS | On-chain org/agent/task/governance | Stable |
-| [fractalmind-envd](/components/envd) | [GitHub](https://github.com/fractalmind-ai/fractalmind-envd) | Go | Remote agent management (SUI + WireGuard) | Active |
-| [agent-manager](/components/agent-manager) | [GitHub](https://github.com/fractalmind-ai/agent-manager-skill) | Python | Agent lifecycle (tmux) | Stable |
-| [team-manager](/components/team-manager) | [GitHub](https://github.com/fractalmind-ai/team-manager-skill) | Python | Team orchestration | Stable |
-| [fractalbot](/components/fractalbot) | [GitHub](https://github.com/fractalmind-ai/fractalbot) | Go | Multi-channel messaging | Active |
-| [okr-manager](/components/okr-manager) | [GitHub](https://github.com/fractalmind-ai/okr-manager-skill) | Skill | OKR lifecycle | Stable |
-| [team-chat](/components/team-chat) | [GitHub](https://github.com/fractalmind-ai/team-chat-skill) | Python | File-backed messaging | Stable |
+| Component | Repo | Role |
+|-----------|------|------|
+| **oh-my-code** | [GitHub](https://github.com/fractalmind-ai/oh-my-code) | Reference workspace where the heartbeat-driven OS runs |
+| **fractalmind-okrs** | [GitHub](https://github.com/fractalmind-ai/fractalmind-okrs) | Candidate OKR publication and review surface |
+| **agent-manager** | [GitHub](https://github.com/fractalmind-ai/agent-manager-skill) | Execution plane for tmux-based agents |
+| **team-manager** | [GitHub](https://github.com/fractalmind-ai/team-manager-skill) | Team orchestration and lead-based coordination |
+| **okr-manager** | [GitHub](https://github.com/fractalmind-ai/okr-manager-skill) | Goal lifecycle and progress tracking |
+| **.github** | [GitHub](https://github.com/fractalmind-ai/.github) | Shared org-level workflows and public profile surface |
 
-## Tool Skills
+## 2. Execution & Collaboration Interfaces
 
-Optional skills that extend agent capabilities.
+These repositories connect humans, agents, and tools.
 
-| Component | Repo | Description |
-|-----------|------|-------------|
-| use-fractalbot | [GitHub](https://github.com/fractalmind-ai/use-fractalbot-skill) | Agent-side message sending |
-| agent-browser | [GitHub](https://github.com/fractalmind-ai/agent-browser-skill) | Headless browser automation |
-| use-phone | [GitHub](https://github.com/fractalmind-ai/use-phone-skill) | ADB Android device control |
-| turbo-frequency | [GitHub](https://github.com/fractalmind-ai/turbo-frequency-skill) | Dynamic heartbeat frequency adjustment |
+| Component | Repo | Role |
+|-----------|------|------|
+| **fractalbot** | [GitHub](https://github.com/fractalmind-ai/fractalbot) | Multi-channel routing across Slack, Telegram, Discord, Feishu, etc. |
+| **team-chat** | [GitHub](https://github.com/fractalmind-ai/team-chat-skill) | File-backed team collaboration and audit trail |
+| **use-fractalbot** | [GitHub](https://github.com/fractalmind-ai/use-fractalbot-skill) | Agent-side outbound messaging skill |
+| **agent-browser** | [GitHub](https://github.com/fractalmind-ai/agent-browser-skill) | Browser automation skill |
+| **use-phone** | [GitHub](https://github.com/fractalmind-ai/use-phone-skill) | Android / ADB control skill |
+| **turbo-frequency** | [GitHub](https://github.com/fractalmind-ai/turbo-frequency-skill) | Dynamic heartbeat frequency control |
 
-## Applications
+## 3. Protocol & Runtime
 
-End-user products built on the FractalMind stack.
+These repositories extend FractalMind into public trust, distributed execution, and visualization.
 
-| Component | Repo | Description |
-|-----------|------|-------------|
-| [oh-my-code](/components/applications) | [GitHub](https://github.com/fractalmind-ai/oh-my-code) | Reference AI agent workspace |
-| [typemind-android](/components/applications) | [GitHub](https://github.com/fractalmind-ai/typemind-android) | Android AI keyboard |
+| Component | Repo | Role |
+|-----------|------|------|
+| **fractalmind-protocol** | [GitHub](https://github.com/fractalmind-ai/fractalmind-protocol) | Optional on-chain trust layer on SUI |
+| **fractalmind-envd** | [GitHub](https://github.com/fractalmind-ai/fractalmind-envd) | Runtime for remote / distributed agent execution |
+| **explorer** | [GitHub](https://github.com/fractalmind-ai/explorer) | Public visualization surface |
+| **openclaw-gateway-app** | [GitHub](https://github.com/fractalmind-ai/openclaw-gateway-app) | Gateway-facing application surface |
 
-## Planned
+## 4. Applications & Distribution
 
-| Component | Role | Phase |
-|-----------|------|-------|
-| Gateway Service | On-chain ↔ off-chain bridge | Phase 3 |
+These are end-user or public-facing surfaces built on top of the stack.
 
-## How They Connect
+| Component | Repo | Role |
+|-----------|------|------|
+| **fractalmind-ai.github.io** | [GitHub](https://github.com/fractalmind-ai/fractalmind-ai.github.io) | Public documentation site |
+| **typemind-android** | [GitHub](https://github.com/fractalmind-ai/typemind-android) | Android AI keyboard product surface |
 
-See the [Architecture Overview](/architecture/overview) for dependency diagrams and data flow.
+## What Matters Most Right Now
+
+The daily operating core today is:
+
+```
+oh-my-code + heartbeat + memory + fractalmind-okrs + agent-manager + fractalbot
+```
+
+That is the current center of gravity.
+
+The protocol, envd, and explorer still matter — but they are now part of a broader **OS-first** story instead of the whole story by themselves.
 
 ## Installation
 
-All skills are distributed via openskills:
+Skills continue to be distributed via openskills:
 
 ```bash
 npx openskills install fractalmind-ai/<skill-name>
 ```
 
-The protocol SDK is available via npm:
+The protocol SDK remains available via npm when you need the trust layer:
 
 ```bash
 npm install @anthropic-ai/fractalmind-sdk

--- a/docs/guide/what-is-fractalmind.md
+++ b/docs/guide/what-is-fractalmind.md
@@ -48,7 +48,7 @@ The important shift is that **FractalMind is now OS-first, not only protocol-fir
 - **AI builders** who need more than a chat bot or single-agent wrapper
 - **Teams operating multiple agents** with real delivery pressure
 - **Researchers** exploring governed autonomy and long-horizon coordination
-- **Organizations** that want auditability, human veto boundaries, and repeatable execution
+- **Organizations** that want auditability, human–AI co-creation, and repeatable execution
 
 ## Current State
 

--- a/docs/guide/what-is-fractalmind.md
+++ b/docs/guide/what-is-fractalmind.md
@@ -1,55 +1,63 @@
 # What is FractalMind?
 
-FractalMind AI is **open-source, permissionless infrastructure** for organizing AI agents into fractal structures.
+FractalMind AI is **open-source infrastructure for running AI agent teams as a governed operating system**.
 
 ## The Problem
 
-Current AI agent frameworks manage individual capabilities:
-- **LangChain** manages tools
-- **CrewAI** manages teams
-- **OpenFang** manages agents
+Most agent tooling stops at one layer:
 
-But none of them manage **organizations** — the recursive, self-similar structures that emerge when you scale beyond a single team.
+- chat interfaces move messages
+- agent frameworks manage one worker at a time
+- team frameworks coordinate a local swarm
+- protocol projects define trust surfaces
 
-## The Solution
+But real delivery needs the whole loop: shared state, priorities, governance, execution, evidence, and learning. Without that, multi-agent work becomes fragile, opaque, and dependent on heroic manual coordination.
 
-FractalMind provides a complete stack for AI organization management:
+## The Current Answer
 
-- **On-chain protocol** (SUI) for permissionless org registration, agent identity, and task lifecycle
-- **Management skills** for agent lifecycle, team orchestration, and OKR tracking
-- **Communication gateway** for multi-channel messaging
-- **Fractal model** where every layer is a complete, self-similar copy of the one above it
+FractalMind combines four surfaces into one operating model:
 
-## How It Works
+- **Communication** — `fractalbot` routes humans and agents across Slack, Telegram, Discord, Feishu, and more
+- **Execution** — `agent-manager` runs tmux-based agents and lets the system dispatch work reliably
+- **Operating system loop** — heartbeat, structured memory, candidate OKRs, governance, outcomes, and evolution
+- **Trust surfaces** — `fractalmind-protocol`, `explorer`, and `fractalmind-envd` extend the system when on-chain identity or distributed execution matters
+
+The control loop is explicit:
 
 ```
-L3+ Inter-Org Federation    DAO governance          Emergent superintelligence
-L2  Organization            fractalmind-protocol    On-chain orgs, agents, tasks
-L1  Agent Team              team-manager            Lead-based team orchestration
-L0  Single Agent            agent-manager           Lifecycle, heartbeat, skills
+signal -> memory -> candidate OKR -> governance -> execution -> outcome -> evolution
 ```
 
-Each layer manages the next using the **same pattern**:
-- **L0**: A single agent has a heartbeat, tasks, and state
-- **L1**: A team has a heartbeat (via its lead), team tasks, and team state
-- **L2**: An organization has a heartbeat (via envd), org tasks, and org state
-- **L3+**: A federation has a heartbeat (via gateway), federated tasks, and federated state
+## How It Works Today
 
-One pattern. Infinite depth.
+```
+L3  Trust & Distribution    protocol / envd / explorer    Optional trust and remote execution
+L2  Operating System        heartbeat + memory + OKRs     Governed coordination and delivery
+L1  Teams & Workflows       team-manager / okr-manager    Team-level planning and tracking
+L0  Single Agent Execution  agent-manager                 Lifecycle, dispatch, and local work
+```
+
+The important shift is that **FractalMind is now OS-first, not only protocol-first**.
+
+- The daily running core lives in `oh-my-code`
+- Shared candidate OKRs land in `fractalmind-okrs`
+- Public trust surfaces still matter, but they are no longer the only story
 
 ## Who Is This For?
 
-- **AI researchers** building multi-agent systems that need organizational structure
-- **Developers** who want to deploy and manage fleets of AI agents
-- **Organizations** exploring autonomous AI operations
-- **Anyone** who believes the future of AI is collaborative, not singular
+- **AI builders** who need more than a chat bot or single-agent wrapper
+- **Teams operating multiple agents** with real delivery pressure
+- **Researchers** exploring governed autonomy and long-horizon coordination
+- **Organizations** that want auditability, human veto boundaries, and repeatable execution
 
-## Current Status
+## Current State
 
-FractalMind is in **Phase 1: Validation**.
+As of the current public org state:
 
-- The protocol is [live on SUI Testnet](https://suiscan.xyz/testnet/object/0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24)
-- Core management skills are stable and in production use
-- SuLabs is the first organization instance with 2 AI agents completing tasks on-chain
+- FractalMind AI spans **18 public repositories**
+- The heartbeat-driven OS loop is running in `oh-my-code`
+- Candidate OKR sync is active through `fractalmind-okrs`
+- The protocol remains live on **SUI Testnet** as an optional trust layer
+- Current work focuses on observability, governed delivery, memory, and distribution — not just proving the protocol exists
 
-See the [Roadmap](/roadmap/) for what's next.
+See the [Architecture Overview](/architecture/overview) and [Roadmap](/roadmap/) for the latest framing.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,68 +1,80 @@
 # Roadmap
 
-FractalMind AI follows a four-phase development plan.
+FractalMind AI has moved from **protocol validation** into **operating-system operationalization**.
 
-## Phase 1: Validation (2026 Q1) — Current
+## Current Track: FractalMind OS v1.0
 
-**Goal**: Core components live, first organization instance on SUI Testnet.
+The active work now centers on making the heartbeat-driven operating loop reliable in practice:
+
+| Focus | Why it matters |
+|------|-----------------|
+| **Heartbeat control loop** | Keep discovery, governance, dispatch, and follow-through running without heroics |
+| **Structured memory** | Make state durable across sessions and agents |
+| **Candidate OKR governance** | Turn raw signals into reviewable, measurable work |
+| **Observability & evidence** | Require logs, QA evidence, sync state, and outcome records |
+| **Distribution surfaces** | Prepare the system to run beyond one workspace or machine |
+
+## Phase 1: Validation — Complete
+
+**Goal**: prove the stack can exist end-to-end.
 
 | Milestone | Status |
 |-----------|--------|
-| fractalmind-protocol Testnet deployment | **Complete** |
-| SuLabs org + 2 agents + 5 tasks on-chain | **Complete** |
-| okr-manager-skill third-party validation | **Complete** |
-| fractalbot multi-channel support | Active |
-| Documentation site | Active |
+| `fractalmind-protocol` live on SUI Testnet | **Complete** |
+| First organization instance on-chain | **Complete** |
+| Core management skills working together | **Complete** |
+| Public docs + GitHub organization surfaces online | **Complete** |
 
-**Success Criteria**: SuLabs registered on SUI Testnet with ≥2 AI agents completing ≥5 task lifecycle cycles on-chain.
+## Phase 2: Operating System — Current
 
-**Status**: Success criteria met.
-
-## Phase 2: Capability (2026 Q2)
-
-**Goal**: Fill the three biggest gaps — security, memory, and tool protocol.
+**Goal**: make FractalMind usable as a governed AI operating system, not just a protocol demo.
 
 | Milestone | Description |
 |-----------|-------------|
-| **Capability Permission System** | Fine-grained, capability-based access control for agent-manager + fractalbot |
-| **Shared Memory Layer** | SQLite + vector search for cross-agent/session knowledge persistence |
-| **MCP Bridge** | Unified tool protocol — openskills supports MCP import/export |
-| **Security Telemetry** | Operation audit chain + prompt injection detection |
+| **Heartbeat OS loop** | `signal -> memory -> candidate OKR -> governance -> execution -> outcome -> evolution` runs as the default operating model |
+| **Shared strategic memory** | Durable state, postmortems, and runtime memory stay coherent across sessions |
+| **Governed autonomy** | Low-risk work can move automatically while high-risk actions stop at clear human boundaries |
+| **Reviewable delivery** | QA evidence, reviewable change sets, and sync state become standard, not optional |
+| **Public narrative alignment** | Website, GitHub, and docs describe the real OS-first system instead of an older protocol-only framing |
 
-## Phase 3: Distribution (2026 Q3)
+## Phase 3: Distribution
 
-**Goal**: Agents can run on any machine, managed remotely.
-
-| Milestone | Description |
-|-----------|-------------|
-| **fractalmind-envd MVP** | Go daemon with WebSocket connection, heartbeat, state discovery |
-| **Gateway Service** | TypeScript service that listens to on-chain events and dispatches to envd |
-| **On-chain Integration** | Tasks automatically recorded on-chain, reputation system operational |
-| **Deployment Automation** | `fractalctl` CLI for one-command installation of core components |
-
-## Phase 4: Emergence (2026 Q4+)
-
-**Goal**: DAO governance loop complete, fractal structures self-operate.
+**Goal**: let the OS run across machines and environments.
 
 | Milestone | Description |
 |-----------|-------------|
-| **DAO → Remote Execution** | On-chain votes trigger agent upgrades/migrations via envd |
-| **Fractal Sub-org Autonomy** | Sub-orgs operate independently with parent oversight |
-| **Inter-Org Federation** | Multiple FractalMind organizations collaborate via cross-org DAO |
-| **Desktop Client** | Optional visual interface for organization management |
+| **fractalmind-envd MVP** | Distributed runtime for remote agent execution |
+| **Gateway / bridge services** | Stronger handoff between trust surfaces and off-chain execution |
+| **Deployment automation** | One-command bootstrap of the core operating stack |
+| **Remote observability** | Health, routing, and state remain inspectable outside one machine |
+
+## Phase 4: Federation
+
+**Goal**: multiple FractalMind systems coordinate as a larger organism.
+
+| Milestone | Description |
+|-----------|-------------|
+| **DAO → execution link** | Governance decisions can safely drive remote changes |
+| **Sub-org autonomy** | Independent sub-systems operate under parent oversight |
+| **Inter-org federation** | Multiple organizations collaborate through shared trust and protocol surfaces |
+| **Operator-grade clients** | Better public and internal interfaces for humans steering the system |
 
 ## Known Gaps
 
-Based on comparative research with existing frameworks:
+| Gap | Impact | Priority |
+|-----|--------|----------|
+| Reviewable delivery still uneven across projects | Changes exist but are not always packaged as clean evidence-backed submissions | P0 |
+| Shared memory depth is still shallow | State is persistent, but cross-project learning remains immature | P1 |
+| Fine-grained capability / security controls | Needed before higher autonomy levels | P1 |
+| Distribution bootstrap remains manual | Slows scaling beyond one primary workspace | P1 |
+| Public narrative lag | Website and org surfaces can drift behind the real operating model | P1 |
 
-| Gap | Impact | Priority | Phase |
-|-----|--------|----------|-------|
-| Weak security model | Agent permissions lack fine-grained control | P0 | Phase 2 |
-| No structured memory | Cross-agent knowledge doesn't persist | P1 | Phase 2 |
-| No unified tool protocol | Tool discovery/invocation not standardized | P1 | Phase 2 |
-| Manual deployment | Each machine needs manual tmux/cron/skills setup | P1 | Phase 3 |
-| No desktop client | CLI-only, high barrier for non-technical users | P2 | Phase 4 |
+## Contributing
 
-## Contributing to the Roadmap
+The best contributions now are the ones that improve **operability**:
 
-We welcome contributions at every phase. Check the [GitHub organization](https://github.com/fractalmind-ai) for open issues, or start a discussion in any repository.
+- make the control loop more reliable
+- improve observability
+- reduce manual coordination
+- produce stronger QA evidence
+- align public docs with the system that actually runs


### PR DESCRIPTION
## Summary
- update the docs site copy from protocol-first to OS-first
- align homepage, architecture, components, guide, and roadmap with the heartbeat-driven operating model
- reflect the current public repo surface and candidate OKR / governance framing

## Validation
- npm run docs:build
- git diff --check