### PR TITLE
feat: Agent OS ROM catalog and installation guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       { text: 'Architecture', link: '/architecture/overview' },
       { text: 'Components', link: '/components/overview' },
       { text: 'Protocol', link: '/protocol/overview' },
+      { text: 'Agent OS', link: '/agent-os/' },
       { text: 'Roadmap', link: '/roadmap/' },
       {
         text: 'Explorer',
@@ -84,6 +85,23 @@ export default defineConfig({
             { text: 'Overview', link: '/protocol/overview' },
             { text: 'TypeScript SDK', link: '/protocol/sdk' },
             { text: 'Testnet Deployment', link: '/protocol/testnet' },
+          ],
+        },
+      ],
+      '/agent-os/': [
+        {
+          text: 'Agent OS',
+          items: [
+            { text: 'ROM Catalog', link: '/agent-os/' },
+            { text: 'Installation Guide', link: '/agent-os/install' },
+          ],
+        },
+        {
+          text: 'Available ROMs',
+          items: [
+            { text: 'manager-heavy-core', link: '/agent-os/roms/manager-heavy-core' },
+            { text: 'trinity', link: '/agent-os/roms/trinity' },
+            { text: 'mentor-coordinator-core', link: '/agent-os/roms/mentor-coordinator-core' },
           ],
         },
       ],

--- a/docs/agent-os/index.md
+++ b/docs/agent-os/index.md
@@ -1,0 +1,91 @@
+# Agent OS
+
+Choose the right AI Agent operating system for your workspace.
+
+Agent OS is a layered system that gives AI agents **persistent memory, goal-driven execution, and structured coordination**. Each OS distribution is called a **ROM** — a pre-configured package of templates, skills, and operating principles that you install into your workspace.
+
+## How It Works
+
+```
+agent-os-spec (contracts)     What every OS must satisfy
+        ↓
+agent-os-roms (distributions)  Concrete OS packages you install
+        ↓
+your workspace                 Where your AI agent lives and works
+```
+
+## Available ROMs
+
+<div class="rom-grid">
+
+### [manager-heavy-core](/agent-os/roms/manager-heavy-core)
+**Production-ready** &middot; v0.5.0
+
+Manager-first coordination OS with full template set, 40+ battle-tested operating principles, OKR control plane, and multi-agent team management.
+
+**Best for:** Multi-agent teams, OKR-driven execution, delegation-first coordination
+
+**Skills:** agent-manager, team-manager + 2 optional
+
+---
+
+### [trinity](/agent-os/roms/trinity)
+**Draft** &middot; v0.1.0
+
+AI employee OS tuned for watched threads, evidence-driven delivery, and strict follow-up discipline. Designed for agents that must act like accountable operators.
+
+**Best for:** Owner-facing AI employees, Slack/IM-heavy execution, strict accountability
+
+**Skills:** agent-manager, use-fractalbot, turbo-frequency
+
+---
+
+### [mentor-coordinator-core](/agent-os/roms/mentor-coordinator-core)
+**Draft** &middot; v0.1.0
+
+Mentor-led coordination OS with surface-first delivery and post-send verification. Optimized for owner-side coordination with Slack and Sentry integration.
+
+**Best for:** Mentor-led workspaces, GitHub + Slack execution tracking
+
+**Skills:** agent-manager, planning-with-files, slack-workspace-inspector, sentry-event-query, use-fractalbot
+
+</div>
+
+## Quick Comparison
+
+| Feature | manager-heavy-core | trinity | mentor-coordinator-core |
+|---------|-------------------|---------|------------------------|
+| Status | Production | Draft | Draft |
+| Version | v0.5.0 | v0.1.0 | v0.1.0 |
+| Template files | 14 | 13 | 5 |
+| Required skills | 2 | 3 | 5 |
+| Optional skills | 2 | — | — |
+| OKR control plane | Full (max 3 active + candidate parking) | Full (max 3 + candidate) | Basic |
+| Memory system | Daily notes + topic index + long-term | Daily notes + topic index + watched threads | Daily notes |
+| Heartbeat mode | Proactive | Proactive | Proactive |
+| Multi-agent | Yes (team-manager) | No | No |
+| Persona | Coordinator-first | Coordinator-first | Coordinator-first |
+
+## Getting Started
+
+Ready to install? See the [Installation Guide](/agent-os/install).
+
+## Learn More
+
+- [agent-os-spec](https://github.com/fractalmind-ai/agent-os-spec) — the contract layer that defines what every OS must satisfy
+- [agent-os-roms](https://github.com/fractalmind-ai/agent-os-roms) — ROM manifests, templates, and release notes
+- [Skills catalog](https://github.com/fractalmind-ai/skills) — all available skills organized by category
+
+<style>
+.rom-grid h3 a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+.rom-grid h3 a:hover {
+  text-decoration: underline;
+}
+.rom-grid hr {
+  margin: 1.5rem 0;
+  border-color: var(--vp-c-divider);
+}
+</style>

--- a/docs/agent-os/install.md
+++ b/docs/agent-os/install.md
@@ -1,0 +1,137 @@
+# Installation Guide
+
+Install an AI Agent OS ROM into your workspace in a few steps.
+
+## Prerequisites
+
+- A workspace directory for your AI agent
+- Git (for fetching skills with `git` source type)
+- An AI agent runtime (e.g., Claude Code, Codex, or any LLM-based agent)
+
+## Step 1: Choose a ROM
+
+Browse the [ROM catalog](/agent-os/) and pick the ROM that matches your use case:
+
+| ROM | Best for |
+|-----|----------|
+| [manager-heavy-core](/agent-os/roms/manager-heavy-core) | Multi-agent teams, OKR-driven execution |
+| [trinity](/agent-os/roms/trinity) | AI employees with strict accountability |
+| [mentor-coordinator-core](/agent-os/roms/mentor-coordinator-core) | Mentor-led coordination |
+
+## Step 2: Clone the ROM templates
+
+```bash
+# Clone the ROMs repository
+git clone https://github.com/fractalmind-ai/agent-os-roms.git
+cd agent-os-roms
+
+# Choose your ROM (example: manager-heavy-core)
+ROM=manager-heavy-core
+```
+
+## Step 3: Copy OS core files
+
+Copy the template files from the ROM into your workspace:
+
+```bash
+# Set your workspace path
+WORKSPACE=~/my-agent-workspace
+
+# Copy all template files
+cp -r roms/$ROM/templates/* $WORKSPACE/
+
+# Create required directories
+mkdir -p $WORKSPACE/memory $WORKSPACE/okrs
+```
+
+This installs the files listed in the ROM's `install_boundary.creates_files`.
+
+## Step 4: Install required skills
+
+Check the ROM's `included_skills` in `manifest.yaml` and install each one:
+
+### Git-sourced skills
+
+```bash
+# Create skills directory
+mkdir -p $WORKSPACE/.agent/skills
+
+# Example: install agent-manager skill
+git clone https://github.com/fractalmind-ai/agent-manager-skill.git \
+  /tmp/agent-manager-skill
+cp -r /tmp/agent-manager-skill/agent-manager \
+  $WORKSPACE/.agent/skills/agent-manager
+```
+
+### Embedded skills
+
+Embedded skills are already included in the ROM's `templates/` directory. They are copied automatically in Step 3.
+
+## Step 5: Install optional skills (recommended)
+
+Check `optional_skills` in the manifest and install any that you need:
+
+```bash
+# Example: install agent-calendar
+git clone --branch v0.1.0 \
+  https://github.com/fractalmind-ai/agent-calendar-skill.git \
+  /tmp/agent-calendar-skill
+cp -r /tmp/agent-calendar-skill/agent-calendar \
+  $WORKSPACE/.agent/skills/agent-calendar
+```
+
+## Step 6: Customize
+
+Edit the following files to match your environment:
+
+1. **`USER.md`** — Add your name, preferences, and collaboration notes
+2. **`TOOLS.md`** — Document local tools, SSH details, API keys (paths only, not secrets)
+3. **`HEARTBEAT.md`** — Configure your execution surface and heartbeat checks
+
+## Step 7: Bootstrap your agent
+
+Point your AI agent to the workspace and let it read `AGENTS.md` on first run. The agent will:
+
+1. Read `SOUL.md` to understand its operating principles
+2. Read `USER.md` to understand who it's helping
+3. Initialize the memory system
+4. Start the heartbeat loop
+
+## Verification
+
+After installation, verify that:
+
+- [ ] All files listed in `install_boundary.creates_files` exist
+- [ ] `memory/` and `okrs/` directories are writable
+- [ ] Each skill in `included_skills` has a `SKILL.md` in `.agent/skills/<name>/`
+- [ ] Your agent can read and follow `AGENTS.md`
+
+## Skill Directory Structure
+
+Each installed skill follows this structure:
+
+```
+.agent/skills/<skill-name>/
+├── SKILL.md          # Entry point — read this to use the skill
+├── scripts/          # Executable scripts
+├── references/       # Reference documentation
+└── rules/            # Optional runtime rules
+```
+
+## What's Next
+
+- Configure your agent's heartbeat schedule
+- Set up your first OKR in `OKR.md`
+- Add tasks to `TODO.md` for immediate work
+- Explore the [Skills catalog](https://github.com/fractalmind-ai/skills) for additional capabilities
+
+## Troubleshooting
+
+**Skill not found after install?**
+Verify the skill directory exists at `.agent/skills/<name>/SKILL.md`. Check that the `source.path` in the manifest matches the directory structure in the git repo.
+
+**Agent doesn't follow OS rules?**
+Ensure `AGENTS.md` is in the workspace root and your agent is configured to read it on session start.
+
+**Missing template files?**
+Re-copy from `roms/<rom-name>/templates/`. Check the manifest's `install_boundary.creates_files` for the complete list.

--- a/docs/agent-os/install.md
+++ b/docs/agent-os/install.md
@@ -44,7 +44,11 @@ cp -r roms/$ROM/templates/* $WORKSPACE/
 mkdir -p $WORKSPACE/memory $WORKSPACE/okrs
 ```
 
-This installs the files listed in the ROM's `install_boundary.creates_files`.
+This copies the ROM's bundled template files. Some ROMs (like `manager-heavy-core`) include all workspace files as templates; others (like `mentor-coordinator-core`) only include core templates and expect the installer to create remaining files listed in `install_boundary.creates_files` as empty or bootstrapped files.
+
+::: tip
+Check each ROM's detail page to see which files are included as templates vs. which need to be created by the installer.
+:::
 
 ## Step 4: Install required skills
 

--- a/docs/agent-os/install.md
+++ b/docs/agent-os/install.md
@@ -36,23 +36,24 @@ Copy the template files from the ROM into your workspace:
 ```bash
 # Set your workspace path
 WORKSPACE=~/my-agent-workspace
+MANIFEST=roms/$ROM/manifest.yaml
 
 # Copy all template files
 cp -r roms/$ROM/templates/* $WORKSPACE/
 
-# Create required directories
-mkdir -p $WORKSPACE/memory $WORKSPACE/okrs
+# Create directories declared in install_boundary.creates_directories
+sed -n '/^ *creates_directories:$/,/^ *[^ -]/{s/^ *- //p}' "$MANIFEST" \
+  | while IFS= read -r d; do mkdir -p "$WORKSPACE/$d"; done
 
-# Create any missing files declared in install_boundary but not bundled as templates.
-# Check the manifest's install_boundary.creates_files and touch any that don't exist yet.
-# For example, mentor-coordinator-core bundles 5 templates but declares 7 files:
-for f in $(grep -A 20 'creates_files:' roms/$ROM/manifest.yaml \
-  | grep '^ *- ' | sed 's/^ *- //'); do
-  [ -e "$WORKSPACE/$f" ] || touch "$WORKSPACE/$f"
+# Create any missing files declared in install_boundary.creates_files
+# (e.g. mentor-coordinator-core bundles 5 templates but declares 7 files)
+sed -n '/^ *creates_files:$/,/^ *[^ -]/{s/^ *- //p}' "$MANIFEST" \
+  | while IFS= read -r f; do
+  [ -e "$WORKSPACE/$f" ] || { mkdir -p "$WORKSPACE/$(dirname "$f")"; touch "$WORKSPACE/$f"; }
 done
 ```
 
-This copies the ROM's bundled template files, then creates any remaining files declared in the manifest as empty bootstrapped files. Some ROMs (like `manager-heavy-core`) include all workspace files as templates; others (like `mentor-coordinator-core`) only include core templates — the loop above handles both cases.
+This copies the ROM's bundled template files, creates declared directories, then bootstraps any missing files as empty. The `sed` commands read only the scoped YAML block (`creates_files` or `creates_directories`), stopping at the next non-list key. Some ROMs (like `manager-heavy-core`) include all workspace files as templates; others (like `mentor-coordinator-core`) only include core templates — the loop handles both cases.
 
 ## Step 4: Install required skills
 

--- a/docs/agent-os/install.md
+++ b/docs/agent-os/install.md
@@ -42,13 +42,17 @@ cp -r roms/$ROM/templates/* $WORKSPACE/
 
 # Create required directories
 mkdir -p $WORKSPACE/memory $WORKSPACE/okrs
+
+# Create any missing files declared in install_boundary but not bundled as templates.
+# Check the manifest's install_boundary.creates_files and touch any that don't exist yet.
+# For example, mentor-coordinator-core bundles 5 templates but declares 7 files:
+for f in $(grep -A 20 'creates_files:' roms/$ROM/manifest.yaml \
+  | grep '^ *- ' | sed 's/^ *- //'); do
+  [ -e "$WORKSPACE/$f" ] || touch "$WORKSPACE/$f"
+done
 ```
 
-This copies the ROM's bundled template files. Some ROMs (like `manager-heavy-core`) include all workspace files as templates; others (like `mentor-coordinator-core`) only include core templates and expect the installer to create remaining files listed in `install_boundary.creates_files` as empty or bootstrapped files.
-
-::: tip
-Check each ROM's detail page to see which files are included as templates vs. which need to be created by the installer.
-:::
+This copies the ROM's bundled template files, then creates any remaining files declared in the manifest as empty bootstrapped files. Some ROMs (like `manager-heavy-core`) include all workspace files as templates; others (like `mentor-coordinator-core`) only include core templates — the loop above handles both cases.
 
 ## Step 4: Install required skills
 

--- a/docs/agent-os/roms/manager-heavy-core.md
+++ b/docs/agent-os/roms/manager-heavy-core.md
@@ -1,0 +1,92 @@
+# manager-heavy-core
+
+> Manager-first AI Agent OS distribution for coordination-heavy workspaces.
+
+| Field | Value |
+|-------|-------|
+| **Status** | Production-ready |
+| **Version** | v0.5.0 |
+| **Family** | manager-heavy |
+| **Spec** | >=1.0.0 \<2.0.0 |
+| **Persona** | Coordinator-first |
+| **Heartbeat** | Proactive |
+
+## Description
+
+Full template set with battle-tested principles, escalation templates, OKR control plane, TODO-first heartbeat, and file-backed memory system. This is the most mature ROM, distilled from production experience managing multi-agent teams.
+
+## Use Cases
+
+- Multi-agent management with delegation
+- OKR-driven execution with max 3 active objectives
+- GitHub-centric development workflows
+- Coordination-first workspaces where the agent orchestrates rather than codes
+
+## Skills
+
+### Required (included_skills)
+
+| Skill | Source | Description |
+|-------|--------|-------------|
+| [agent-manager](https://github.com/fractalmind-ai/agent-manager-skill) | git | Employee agent lifecycle management — start, stop, monitor, assign tasks |
+| [team-manager](https://github.com/fractalmind-ai/team-manager-skill) | git | Team orchestration — create teams, assign tasks, monitor progress |
+
+### Optional (optional_skills)
+
+| Skill | Source | Description |
+|-------|--------|-------------|
+| [agent-calendar](https://github.com/fractalmind-ai/agent-calendar-skill) | git (v0.1.0) | Agent availability calendar — track free/busy/unavailable states, monitor quotas |
+| notifier | embedded | Multi-channel notifications — Feishu, Slack, Telegram, email |
+
+## Workspace Files
+
+After installation, your workspace will contain:
+
+### Core OS files
+| File | Purpose |
+|------|---------|
+| `SYSTEM.md` | Kernel contract with manager principles and operating rules |
+| `SOUL.md` | 40+ operating principles across 11 categories |
+| `AGENTS.md` | Session bootstrap, memory rules, structure invariants |
+| `USER.md` | Operator profile template |
+| `HEARTBEAT.md` | TODO-first execution surface with 3-gate criteria |
+| `OKR.md` | Active OKR control plane (max 3) |
+| `TODO.md` | High-priority temporary work tracker |
+| `MEMORY.md` | Long-term curated memory |
+| `TOOLS.md` | Local tools and environment notes |
+
+### Memory system
+| Path | Purpose |
+|------|---------|
+| `memory/index.md` | Topic navigation index |
+| `memory/YYYY-MM-DD.md` | Daily notes (created as needed) |
+
+### OKR system
+| Path | Purpose |
+|------|---------|
+| `okrs/Candidate.md` | Non-active OKR parking lot |
+
+## Key Principles
+
+- **TODO-first heartbeat**: Temporary urgent work is resolved before OKR progression
+- **3-gate HEARTBEAT_OK**: Must pass external-wait + no-internal-action + fresh-scan before returning OK
+- **Max 3 active OKRs**: Non-active OKRs park in `okrs/Candidate.md`
+- **File-backed memory**: Daily notes + topic index + long-term curated memory
+- **Escalation templates**: Standardized approval request and blocker report formats
+- **Evidence-based OKR closure**: 8 rules for closing objectives with proof
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| v0.5.0 | 2026-04-16 | agent-calendar open-sourced, switched to git source |
+| v0.4.0 | 2026-04-16 | Embedded skills bundled, skill classification (included/optional) |
+| v0.3.0 | 2026-04-16 | Structured skill source declarations |
+| v0.2.0 | 2026-04-15 | Full 11-file template set, TODO-first heartbeat |
+| v0.1.0 | 2026-03-26 | Bootstrap draft |
+
+[View full release notes on GitHub](https://github.com/fractalmind-ai/agent-os-roms/blob/main/roms/manager-heavy-core/release-notes.md)
+
+## Install
+
+See the [Installation Guide](/agent-os/install) for step-by-step instructions.

--- a/docs/agent-os/roms/mentor-coordinator-core.md
+++ b/docs/agent-os/roms/mentor-coordinator-core.md
@@ -1,0 +1,76 @@
+# mentor-coordinator-core
+
+> Mentor-led coordination-first AI Agent OS distribution with TODO-first heartbeat execution, file-backed memory, and strict surface verification.
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft |
+| **Version** | v0.1.0 |
+| **Family** | manager-heavy |
+| **Spec** | >=1.0.0 \<2.0.0 |
+| **Persona** | Coordinator-first |
+| **Heartbeat** | Proactive |
+
+## Description
+
+A mentor-led variant of the manager-heavy family. Optimized for owner-side coordination with integrated Slack workspace inspection and Sentry error tracking. Surface-first delivery ensures every action is verified, not just attempted.
+
+## Use Cases
+
+- Mentor-led workspaces where the agent coordinates under guidance
+- Multi-agent coordination with GitHub and Slack execution tracking
+- Workspaces requiring Sentry integration for error monitoring
+- Environments needing structured planning via file-based workflows
+
+## Skills
+
+### Required (included_skills)
+
+| Skill | Description |
+|-------|-------------|
+| agent-manager | Employee agent lifecycle management |
+| planning-with-files | File-based planning and tracking workflows |
+| slack-workspace-inspector | Slack workspace monitoring and inspection |
+| sentry-event-query | Sentry error event querying and analysis |
+| use-fractalbot | Outbound messaging via fractalbot CLI |
+
+## Workspace Files
+
+After installation, your workspace will contain:
+
+### Core OS files
+| File | Purpose |
+|------|---------|
+| `SYSTEM.md` | Kernel contract |
+| `SOUL.md` | Operating principles |
+| `AGENTS.md` | Session bootstrap and rules |
+| `USER.md` | Operator profile |
+| `HEARTBEAT.md` | TODO-first execution surface |
+| `OKR.md` | Active OKR control plane |
+| `TODO.md` | Temporary work tracker |
+
+### Directories
+| Path | Purpose |
+|------|---------|
+| `memory/` | Daily notes storage |
+| `okrs/` | OKR artifacts |
+
+## Key Principles
+
+- **Surface-first delivery**: Verify every action reaches its intended surface
+- **Post-send verification**: Not just "sent" but confirmed delivered
+- **TODO-first heartbeat**: Urgent work before OKR progression
+- **File-backed memory**: Persistent context across sessions
+- **Coordination-optimized**: Built for orchestration, not isolated coding
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| v0.1.0 | 2026-03-29 | Bootstrap draft with coordination-type contracts |
+
+[View full release notes on GitHub](https://github.com/fractalmind-ai/agent-os-roms/blob/main/roms/mentor-coordinator-core/release-notes.md)
+
+## Install
+
+See the [Installation Guide](/agent-os/install) for step-by-step instructions.

--- a/docs/agent-os/roms/mentor-coordinator-core.md
+++ b/docs/agent-os/roms/mentor-coordinator-core.md
@@ -36,22 +36,27 @@ A mentor-led variant of the manager-heavy family. Optimized for owner-side coord
 
 ## Workspace Files
 
-After installation, your workspace will contain:
+### Included templates (5 files)
 
-### Core OS files
+These files are bundled in the ROM and copied during installation:
+
 | File | Purpose |
 |------|---------|
 | `SYSTEM.md` | Kernel contract |
 | `SOUL.md` | Operating principles |
 | `AGENTS.md` | Session bootstrap and rules |
-| `USER.md` | Operator profile |
 | `HEARTBEAT.md` | TODO-first execution surface |
-| `OKR.md` | Active OKR control plane |
-| `TODO.md` | Temporary work tracker |
+| `README.md` | Workspace overview |
 
-### Directories
+### Created by installer (empty / bootstrapped)
+
+The manifest expects these files and directories to exist. The installer should create them as empty or with minimal bootstrapped content:
+
 | Path | Purpose |
 |------|---------|
+| `USER.md` | Operator profile (customize after install) |
+| `OKR.md` | Active OKR control plane |
+| `TODO.md` | Temporary work tracker |
 | `memory/` | Daily notes storage |
 | `okrs/` | OKR artifacts |
 

--- a/docs/agent-os/roms/trinity.md
+++ b/docs/agent-os/roms/trinity.md
@@ -1,0 +1,81 @@
+# trinity
+
+> A coordination-first AI employee OS tuned for watched threads, TODO-first heartbeat execution, file-backed memory, and evidence-driven delivery.
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft |
+| **Version** | v0.1.0 |
+| **Family** | manager-heavy |
+| **Spec** | >=1.0.0 \<2.0.0 |
+| **Persona** | Coordinator-first |
+| **Heartbeat** | Proactive |
+
+## Description
+
+Trinity is designed for AI agents that must act like **accountable operators**, not passive chatbots. It emphasizes watched DM/thread environments where every action needs a short receipt, strict follow-up discipline, and evidence-driven delivery.
+
+## Use Cases
+
+- Owner-facing AI employee workspaces
+- Slack / IM-heavy execution loops
+- Multi-agent coordination with strict follow-up discipline
+- Environments where every outbound message requires post-send verification
+
+## Skills
+
+### Required (included_skills)
+
+| Skill | Description |
+|-------|-------------|
+| agent-manager | Employee agent lifecycle management |
+| use-fractalbot | Outbound messaging via fractalbot CLI |
+| turbo-frequency | High-frequency execution mode |
+
+## Workspace Files
+
+After installation, your workspace will contain:
+
+### Core OS files
+| File | Purpose |
+|------|---------|
+| `SYSTEM.md` | Kernel contract |
+| `SOUL.md` | Operating principles |
+| `AGENTS.md` | Session bootstrap and rules |
+| `USER.md` | Operator profile |
+| `HEARTBEAT.md` | TODO-first execution surface |
+| `OKR.md` | Active OKR control plane |
+| `TODO.md` | Temporary work tracker |
+| `MEMORY.md` | Long-term memory |
+| `TOOLS.md` | Environment notes |
+
+### Memory system
+| Path | Purpose |
+|------|---------|
+| `memory/index.md` | Topic navigation |
+| `memory/watched-dm-receipts.md` | Watched thread receipts |
+
+### OKR system
+| Path | Purpose |
+|------|---------|
+| `okrs/Candidate.md` | Non-active OKR parking lot |
+
+## Key Principles
+
+- **Result-oriented, not step-oriented**: Focus on outcomes, not process
+- **Post-send verification**: Not just "sent" but "delivered correctly"
+- **Watched DM/thread discipline**: Every action change produces a short receipt
+- **TODO-first heartbeat**: Urgent work before OKR progression
+- **Evidence-driven delivery**: Prove completion with artifacts
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| v0.1.0 | 2026-04-12 | Initial draft — AI employee OS with watched thread discipline |
+
+[View full release notes on GitHub](https://github.com/fractalmind-ai/agent-os-roms/blob/main/roms/trinity/release-notes.md)
+
+## Install
+
+See the [Installation Guide](/agent-os/install) for step-by-step instructions.


### PR DESCRIPTION
## Summary
- New **Agent OS** section at `/agent-os/` with ROM catalog, comparison table, and installation guide
- Detail pages for all 3 ROMs: manager-heavy-core (production), trinity (draft), mentor-coordinator-core (draft)
- Step-by-step installation guide with skill fetching instructions
- Integrated into top nav and sidebar

## Pages added
- `/agent-os/` — ROM catalog with cards and comparison table
- `/agent-os/install` — Installation guide (clone → copy → install skills → customize → bootstrap)
- `/agent-os/roms/manager-heavy-core` — Detail page (v0.5.0, production)
- `/agent-os/roms/trinity` — Detail page (v0.1.0, draft)
- `/agent-os/roms/mentor-coordinator-core` — Detail page (v0.1.0, draft)

## Test plan
- [x] VitePress build passes (`npm run docs:build`)
- [ ] Visual review of all pages
- [ ] Navigation links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)